### PR TITLE
feat: Codexレビューのeffortをhighに固定（peer-review / self-review）

### DIFF
--- a/private_dot_claude/skills/peer-review/scripts/executable_codex-review.sh
+++ b/private_dot_claude/skills/peer-review/scripts/executable_codex-review.sh
@@ -69,7 +69,12 @@ trap 'rm -f "$JSONL_FILE" "$LAST_FILE"' EXIT
 >&2 echo "[peer-review] Codex review 実行中 (base=$BASE_BRANCH)..."
 
 # Codex を非対話で実行。PROMPT は渡さない（--base と排他のため）
+# -c model_reasoning_effort=high: L2 セカンドオピニオンは質が命なので effort を high に固定する。
+#   --ignore-user-config で config.toml を無視するため、-c 明示指定で effort を上書きする
+#   （委譲パスのグローバル default は medium に下げてレートを節約しているが、低頻度な
+#    レビューだけは high を選ぶメリハリ運用）
 codex exec review \
+  -c model_reasoning_effort=high \
   --base "$BASE_BRANCH" \
   --json \
   --ignore-user-config \

--- a/private_dot_claude/skills/self-review/references/review-prompts.md
+++ b/private_dot_claude/skills/self-review/references/review-prompts.md
@@ -188,6 +188,7 @@ trap 'rm -f "$TMP"' EXIT
   cat -
   echo '```'
 } <<< "$DIFF" | codex exec \
+  -c model_reasoning_effort=high \
   --output-schema "$SCHEMA" \
   --output-last-message "$TMP" \
   --sandbox read-only \
@@ -198,6 +199,8 @@ cat "$TMP"
 ```
 
 `$CODEX_REPRO_FLAGS` は Step 0 で `codex >= 0.122` のとき `--ignore-user-config --ignore-rules` に展開される（古い codex では空文字）。
+
+`-c model_reasoning_effort=high` は外部レビューの effort を high に固定する。`--ignore-user-config` で `~/.codex/config.toml` を無視するため、effort を狙った値にするには `-c` 明示指定が必須。委譲パスのグローバル default は medium に下げてレートを節約しつつ、低頻度なセカンドオピニオンだけ high を選ぶメリハリ運用（委譲パスは config.toml を尊重するが、レビュー系は `--ignore-user-config` で読まない）。
 
 ### 呼び出し例（design 観点を Claude-p に投げる、`--with-design` 時のデフォルト）
 
@@ -347,6 +350,7 @@ trap 'rm -f "$TMP"' EXIT
   echo "$DIFF"
   echo '```'
 } | codex exec \
+  -c model_reasoning_effort=high \
   --output-schema "$SCHEMA" \
   --output-last-message "$TMP" \
   --sandbox read-only \


### PR DESCRIPTION
## 概要

Codex のレート消費急増対策の一環。委譲パス（task-delegation の T2 default）のグローバル default を `medium` に下げてレートを節約しつつ、低頻度で質が重要なセカンドオピニオン（peer-review L2 / self-review security）だけ Codex の reasoning effort を `high` に固定する「メリハリ運用」を導入する。

### 背景

- Codex のレート消費が急増していた。原因は `~/.codex/config.toml` の `model_reasoning_effort = "xhigh"`（最上位）× 委譲量増の掛け算（config.toml は chezmoi 管理外のため本 PR には含まれない。別途 `medium` に変更済み）
- review系スキル（peer-review / self-review）は `codex exec --ignore-user-config` で `config.toml` を無視するため、effort を狙った値にするには `-c model_reasoning_effort=high` の明示指定が必須

### 変更内容

- `peer-review/scripts/codex-review.sh`: `codex exec review` に `-c model_reasoning_effort=high` を追加
- `self-review/references/review-prompts.md`: 2箇所の `codex exec` に同フラグを追加 + 意図の注記を追記

## テスト計画

- [ ] peer-review 実行時、Codex が high effort で動作することを確認
- [ ] self-review（security 観点）実行時、Codex が high effort で動作することを確認
- [ ] 委譲パス（通常タスク）が引き続き medium で動作し、レート消費が抑制されていることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * コード レビュー実行時の推論努力レベル設定に関する説明とコマンド例を更新しました。

* **その他**
  * レビュー品質向上のため、内部設定パラメータを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->