### PR TITLE
docs: Codex effort 制御マップを codex-account スキルに追記

### DIFF
--- a/private_dot_claude/skills/codex-account/SKILL.md
+++ b/private_dot_claude/skills/codex-account/SKILL.md
@@ -96,6 +96,20 @@ codex-work
 自動 failover（429 検知で別アカウント再試行するラッパー）は、委譲先 Codex の常駐プロセスへの
 割り込みが壊れやすいため**作らない**。
 
+## Codex effort 制御マップ（レート消費の主因）
+
+`model_reasoning_effort`（reasoning effort）は **呼び出しパスによって `~/.codex/config.toml` を尊重するか無視するかが分かれる**。「effort を変えたのに効かない」「想定外にレートが減る」の原因切り分け表。
+
+| パス | config.toml を尊重? | effort の変え方 | レート消費 |
+|---|---|---|---|
+| 委譲（task-delegation T2 default / `/codex:rescue`） | ✅ する（`codex app-server` を `--ignore-user-config` なしで起動） | `~/.codex/config.toml` の `model_reasoning_effort` | **大（本丸）** |
+| peer-review L2 / self-review（`codex exec --ignore-user-config`） | ❌ 無視 | スクリプトに `-c model_reasoning_effort=<x>` を明示指定（`-c` は `--ignore-user-config` があっても効く） | 小（低頻度） |
+
+運用方針（メリハリ）:
+- **委譲（大量・定型）= `config.toml` で `medium`** に下げてレート節約。レートが急増したら**まずここの `xhigh` を疑う**
+- **レビュー系（少量・質重視）= `-c model_reasoning_effort=high` で固定**。実装は `peer-review/scripts/codex-review.sh` と `self-review/references/review-prompts.md` のインラインコメント参照
+- `~/.codex/config.toml` は chezmoi **管理外**（直接編集が永続。dotfiles リポジトリには含まれない）
+
 ## アンチパターン
 
 | ❌ NG | ✅ OK |


### PR DESCRIPTION
## 概要

Codex の `model_reasoning_effort`（reasoning effort）が **呼び出しパスによって `~/.codex/config.toml` を尊重するか無視するか分かれる**、という非自明な事実を「Codex effort 制御マップ」として `codex-account` スキルに記録する。

PR #7 で各呼び出し箇所のインラインコメントは追加済みだが、「どのパスが config.toml を尊重し、どれが無視するか」という横断的な制御マップはリポジトリのどこにも中央集約されていなかった。別マシン・他の利用者が「effort を変えたのに config.toml が効かない」と詰まったとき、同じ調査をゼロからやり直す再発見コストを下げるのが狙い。

### 記録した内容

- **委譲パス**（task-delegation T2 default / `/codex:rescue`）= `codex app-server` を `--ignore-user-config` なしで起動 → config.toml を尊重。レート消費の本丸
- **review系**（peer-review / self-review の `codex exec --ignore-user-config`）= config.toml を無視 → effort 制御は `-c model_reasoning_effort=` の明示指定が必須
- メリハリ運用（委譲=medium で節約、レビュー系=high 固定）の方針も併記

### 配置先

`codex-account` スキルの「レートリミット退避」セクション直後（Codex 設定・レートをいじる人が自然に見る場所）。

## テスト計画

- ドキュメントのみの変更（コード変更なし）
- [ ] レンダリング確認（表が正しく表示されるか）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Codex effort制御に関するドキュメントを更新。レート消費の主因となる制御マップと、設定ファイルの尊重・無視に関する運用方針を新たに記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->