### PR TITLE
feat: Codex トレースログの自動プルーンを cleanup hook に追加

### DIFF
--- a/private_dot_claude/hooks/executable_cleanup.sh
+++ b/private_dot_claude/hooks/executable_cleanup.sh
@@ -11,3 +11,29 @@ RETENTION_DAYS=3
 # 3日以上古いファイルを削除（長期セッションの保護）
 find "${CLAUDE_DIR}/todos" -type f -name "*.json" -mtime +${RETENTION_DAYS} -delete 2>/dev/null || true
 find "${CLAUDE_DIR}/shell-snapshots" -type f -name "*.sh" -mtime +${RETENTION_DAYS} -delete 2>/dev/null || true
+
+# Codex CLI トレースログ（logs_*.sqlite）の肥大防止
+# Codex は自動 retention を持たず logs テーブルに無限追記する（実測 ~48MB/日）。
+# RETENTION_DAYS より古い行を削除し、Codex 非走行時かつ 50MB 超のときだけ VACUUM で実圧縮する。
+#   - DELETE: WAL + busy_timeout により走行中でも整合性が保たれる（best-effort、失敗は無視）
+#   - VACUUM: 排他ロックが必要なため app-server 非走行時のみ。毎回の無駄を避け 50MB 超で限定実行
+#   - logs_* ワイルドカード: スキーマ版数による filename 変更（logs_2 → logs_3 …）に追従
+#   - ~/.codex-work: codex-account スキルの work アカウント CODEX_HOME も対象に含める
+if command -v sqlite3 >/dev/null 2>&1; then
+  codex_log_cutoff=$(( $(date +%s) - RETENTION_DAYS * 86400 ))
+  codex_running=1
+  pgrep -f 'codex app-server' >/dev/null 2>&1 || codex_running=0
+  for codex_home in "${HOME}/.codex" "${HOME}/.codex-work"; do
+    [ -d "${codex_home}" ] || continue
+    for log_db in "${codex_home}"/logs_*.sqlite; do
+      [ -f "${log_db}" ] || continue
+      sqlite3 "${log_db}" "PRAGMA busy_timeout=3000; DELETE FROM logs WHERE ts < ${codex_log_cutoff};" >/dev/null 2>&1 || true
+      if [ "${codex_running}" -eq 0 ]; then
+        db_size=$(stat -f%z "${log_db}" 2>/dev/null || echo 0)
+        if [ "${db_size}" -gt 52428800 ]; then
+          sqlite3 "${log_db}" "PRAGMA busy_timeout=3000; VACUUM;" >/dev/null 2>&1 || true
+        fi
+      fi
+    done
+  done
+fi


### PR DESCRIPTION
## 概要

Codex CLI のトレースログ（`~/.codex/logs_*.sqlite`）の肥大を自動で防ぐため、Claude Code 既存の `cleanup.sh`（Stop hook・3日保持）に Codex ログのプルーン処理を追加し、ログ管理を同じ仕組みに統一する。

### 背景

- Codex CLI の `logs_2.sqlite` は自動 retention（保持期間・サイズ上限）を持たず、`logs` テーブルに無限追記される。実測で **~48MB/日**、調査時点で **528MB / 212k 行**まで肥大していた（大半が TRACE / INFO の診断ログ）
- ファイル名の番号はスキーマ版数であり、サイズ超過によるローテーションではない＝放置すると延々と増える
- Claude Code 側は `cleanup.sh` で `todos` / `shell-snapshots` を自動クリーンアップ済み。Codex 側に同等の仕組みが無かった

### 変更内容（`cleanup.sh` に追記）

- `RETENTION_DAYS`（3日）より古い `logs` 行を `DELETE`
  - **DELETE**: WAL + `busy_timeout` により Codex 走行中でも整合性が保たれる（best-effort、失敗は無視）
  - **VACUUM**: 排他ロックが必要なため `codex app-server` 非走行時のみ。毎回の無駄を避けるため 50MB 超のときだけ実行
- `logs_*` ワイルドカードでスキーマ版数の filename 変更（`logs_2` → 将来 `logs_3` …）に追従
- `~/.codex-work`（codex-account スキルの work アカウント `CODEX_HOME`）も対象に含める

### 動作確認

- 構文チェック（`bash -n`）パス
- 実行で `211,134 → 83,249` 行にプルーン（残存最古ログが3日以内になることを確認）
- Stop hook の stdout が無音であることを確認（`PRAGMA busy_timeout` の値 echo を抑制）

## テスト計画

- [ ] Codex 非走行時の Stop で VACUUM が走り、ファイルサイズが実サイズまで縮小することを確認
- [ ] Codex 走行中の Stop では VACUUM がスキップされ、走行中プロセスに影響しないことを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Codex CLI のトレースログの自動クリーンアップ機能を強化しました。古いログエントリの削除と、データベースファイルの最適化が自動的に実行されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->