### PR TITLE
feat(statusline): Open PR リンク表示と 2 段レイアウト対応

### DIFF
--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -44,6 +44,45 @@ if [[ -n "$project_dir" && ( -d "$project_dir/.git" || -f "$project_dir/.git" ) 
   fi
 fi
 
+# --- Open PR for current branch (cached per branch, 60s TTL) ---
+# Replicates the open-PR indicator Claude Code's default statusline used to show.
+# gh is a network call, so cache aggressively and guard every read (set -euo pipefail safe).
+pr_number=""; pr_url=""
+if [[ -n "$branch" && -n "$project_dir" ]] && command -v gh >/dev/null 2>&1; then
+  pr_cache="${cache_file}.pr"
+  use_pr_cache=""
+  if [[ -f "$pr_cache" ]]; then
+    pr_ctime=$(sed -n '1p' "$pr_cache" 2>/dev/null || echo 0); pr_ctime=${pr_ctime:-0}
+    pr_cbranch=$(sed -n '2p' "$pr_cache" 2>/dev/null || echo "")
+    if [[ "$pr_cbranch" == "$branch" ]] && (( now - pr_ctime < 60 )); then
+      pr_number=$(sed -n '3p' "$pr_cache" 2>/dev/null || echo "")
+      pr_url=$(sed -n '4p' "$pr_cache" 2>/dev/null || echo "")
+      use_pr_cache=1
+    fi
+  fi
+  if [[ -z "$use_pr_cache" ]]; then
+    pr_line=$( (cd "$project_dir" && gh pr view --json number,url,state 2>/dev/null) \
+      | jq -r 'select(.state=="OPEN") | "\(.number)\t\(.url)"' 2>/dev/null || true )
+    if [[ "$pr_line" == *$'\t'* ]]; then
+      pr_number="${pr_line%%$'\t'*}"
+      pr_url="${pr_line#*$'\t'}"
+    else
+      pr_number=""; pr_url=""
+    fi
+    printf '%s\n%s\n%s\n%s\n' "$now" "$branch" "$pr_number" "$pr_url" > "$pr_cache"
+  fi
+fi
+
+# --- PR segment (clickable OSC 8 hyperlink when URL is known) ---
+pr_seg=""
+if [[ -n "$pr_number" ]]; then
+  if [[ -n "$pr_url" ]]; then
+    pr_seg="\033[34m\033]8;;${pr_url}\033\134PR #${pr_number}\033]8;;\033\134\033[0m"
+  else
+    pr_seg="\033[34mPR #${pr_number}\033[0m"
+  fi
+fi
+
 # --- Context bar color ---
 if (( used >= 80 )); then
   bar_color="31"   # red
@@ -97,10 +136,12 @@ if [[ -n "$rl_label" ]]; then
   fi
 fi
 
-# --- Compose line (responsive) ---
-# Using printf '%b' for reliable escape handling across shells
+# --- Compose lines (responsive; wide/medium render two rows) ---
+# Row 1 = identity (project | branch | PR), Row 2 = metrics (context | model | cost | rate-limit).
+# Narrow stays a single row. Using printf '%b' for reliable escape handling across shells.
+line1=""; line2=""
 if (( cols >= 90 )); then
-  # Wide: project | branch | ▓▓▓░░░░░░░ XX% | model $X.XX
+  # Wide
   bar_width=10
   filled=$(( used * bar_width / 100 ))
   (( filled > bar_width )) && filled=$bar_width
@@ -109,24 +150,31 @@ if (( cols >= 90 )); then
   for (( i=0; i<filled; i++ )); do bar+="▓"; done
   for (( i=0; i<empty; i++ ));  do bar+="░"; done
 
-  line="\033[36;1m${project}\033[0m"
-  [[ -n "$branch" ]] && line+=" \033[2m|\033[0m \033[35m${branch}\033[0m"
-  line+=" \033[2m|\033[0m \033[${bar_color}m${bar}\033[0m \033[${bar_color}m${used}%\033[0m"
-  line+=" \033[2m|\033[0m ${model} \033[2m${cost_fmt}\033[0m"
-  [[ -n "$rl_full" ]] && line+=" \033[2m|\033[0m ${rl_full}"
+  # Row 1: project | branch | PR
+  line1="\033[36;1m${project}\033[0m"
+  [[ -n "$branch" ]] && line1+=" \033[2m|\033[0m \033[35m${branch}\033[0m"
+  [[ -n "$pr_seg" ]] && line1+=" \033[2m|\033[0m ${pr_seg}"
+  # Row 2: ▓▓▓░░ XX% | model $X.XX | rate-limit
+  line2="\033[${bar_color}m${bar}\033[0m \033[${bar_color}m${used}%\033[0m"
+  line2+=" \033[2m|\033[0m ${model} \033[2m${cost_fmt}\033[0m"
+  [[ -n "$rl_full" ]] && line2+=" \033[2m|\033[0m ${rl_full}"
 
 elif (( cols >= 60 )); then
-  # Medium: project | branch | XX% | $X.XX
-  line="\033[36;1m${project}\033[0m"
-  [[ -n "$branch" ]] && line+=" \033[2m|\033[0m \033[35m${branch}\033[0m"
-  line+=" \033[2m|\033[0m \033[${bar_color}m${used}%\033[0m"
-  line+=" \033[2m|\033[0m \033[2m${cost_fmt}\033[0m"
-  [[ -n "$rl_full" ]] && line+=" \033[2m|\033[0m ${rl_full}"
+  # Medium
+  # Row 1: project | branch | PR
+  line1="\033[36;1m${project}\033[0m"
+  [[ -n "$branch" ]] && line1+=" \033[2m|\033[0m \033[35m${branch}\033[0m"
+  [[ -n "$pr_seg" ]] && line1+=" \033[2m|\033[0m ${pr_seg}"
+  # Row 2: XX% | $X.XX | rate-limit
+  line2="\033[${bar_color}m${used}%\033[0m"
+  line2+=" \033[2m|\033[0m \033[2m${cost_fmt}\033[0m"
+  [[ -n "$rl_full" ]] && line2+=" \033[2m|\033[0m ${rl_full}"
 
 else
-  # Narrow: project XX% $X.XX  (rate-limit shown only when critical)
-  line="\033[36m${project}\033[0m \033[${bar_color}m${used}%\033[0m \033[2m${cost_fmt}\033[0m"
-  [[ -n "$rl_short" ]] && line+=" ${rl_short}"
+  # Narrow: single row — project XX% $X.XX (rate-limit shown only when critical)
+  line1="\033[36m${project}\033[0m \033[${bar_color}m${used}%\033[0m \033[2m${cost_fmt}\033[0m"
+  [[ -n "$rl_short" ]] && line1+=" ${rl_short}"
 fi
 
-printf '%b\n' "$line"
+printf '%b\n' "$line1"
+[[ -n "$line2" ]] && printf '%b\n' "$line2"

--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -173,7 +173,7 @@ elif (( cols >= 60 )); then
 else
   # Narrow: single row — project XX% $X.XX (rate-limit shown only when critical)
   line1="\033[36m${project}\033[0m \033[${bar_color}m${used}%\033[0m \033[2m${cost_fmt}\033[0m"
-  [[ -n "$rl_short" ]] && line1+=" ${rl_short}"
+  (( rl_max >= RL_CRIT )) && [[ -n "$rl_short" ]] && line1+=" ${rl_short}"
 fi
 
 printf '%b\n' "$line1"

--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -52,7 +52,7 @@ if [[ -n "$branch" && -n "$project_dir" ]] && command -v gh >/dev/null 2>&1; the
   pr_cache="${cache_file}.pr"
   use_pr_cache=""
   if [[ -f "$pr_cache" ]]; then
-    pr_ctime=$(sed -n '1p' "$pr_cache" 2>/dev/null || echo 0); pr_ctime=${pr_ctime:-0}
+    pr_ctime=$(sed -n '1p' "$pr_cache" 2>/dev/null || echo 0); pr_ctime=${pr_ctime//[^0-9]/}; pr_ctime=${pr_ctime:-0}
     pr_cbranch=$(sed -n '2p' "$pr_cache" 2>/dev/null || echo "")
     if [[ "$pr_cbranch" == "$branch" ]] && (( now - pr_ctime < 60 )); then
       pr_number=$(sed -n '3p' "$pr_cache" 2>/dev/null || echo "")


### PR DESCRIPTION
## 概要

Claude Code のカスタム statusline（`private_dot_claude/executable_statusline.sh`）に 2 つの改善を加える。

1. **現ブランチの Open PR をクリック可能なリンクで表示**
   - Claude Code デフォルト statusline がかつて表示していた「Open PR インジケータ」を、カスタム statusline 側で再現する
   - `gh pr view` で現ブランチの Open PR を取得し、`PR #<番号>` を OSC 8 ハイパーリンクとして描画（WezTerm 等でクリックすると当該 PR が開く）
   - OPEN の PR のみ対象。`gh` 未認証 / 未インストール / PR 無しのときは黙ってスキップ
   - `gh` はネットワーク呼び出しのため **60 秒・ブランチ単位でキャッシュ**。キャッシュヒット時の描画は実測 0.06 秒

2. **wide / medium 幅を 2 段表示に変更**
   - 1 段目: 識別情報（`project | branch | PR`）
   - 2 段目: メトリクス（コンテキストバー | model | cost | rate-limit）
   - narrow 幅は省スペース維持のため従来どおり 1 行

### 背景

カスタム statusline を設定すると Claude Code 組み込みのステータス表示は完全に置き換わるため、デフォルトで出ていた Open PR リンクが見えなくなっていた。本変更でカスタム側に同等表示を実装する。

## テスト計画

- [x] `bash -n` 構文チェック OK
- [x] wide（cols=120）: 2 段表示・2 段目にコンテキストバー・PR リンク描画を確認
- [x] medium（cols=70）: 2 段表示・2 段目はバー無しの簡易メトリクスを確認
- [x] narrow（cols=40）: 1 行表示を維持することを確認
- [x] OSC 8 ハイパーリンクのエスケープシーケンスを `cat -v` で検証
- [x] 60 秒キャッシュの生成・再利用と描画速度（0.06s）を確認
- [x] `set -euo pipefail` 下で全読み取りをガード（PR 無し・gh 不在でも非エラー終了）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 現行Gitブランチの「OPEN PR」をステータスラインに表示
  * OPEN PR情報を60秒キャッシュして表示を高速化
  * 対応端末ではPR URLをハイパーリンク表示
* **改善**
  * 画面幅に応じてステータスラインを再レイアウト（ワイドは2行表示、幅により表示項目を最適化）
  * レート制限表示や表示項目の切替を調整し、内容を分かりやすくしました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->