### PR TITLE
feat(skills): github-api-efficient スキル追加（レートリミット対応の gh キャッシュ）

### DIFF
--- a/private_dot_claude/skills/github-api-efficient/SKILL.md
+++ b/private_dot_claude/skills/github-api-efficient/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: github-api-efficient
+description: GitHub API / gh CLI を使う前に、最もレートリミット効率の良いメソッド選択・静的キャッシュ・事前budgetチェックを強制する規律スキル。`gh api` / `gh project item-list` / `gh issue list` / GraphQL での Issue・Project・PR の取得、一括操作、「GitHub から取得」「一覧取得」「棚卸し」等の依頼時、特に件数が多い・ループする・繰り返し取得する場面の前に必ず使用する。レートリミット枯渇（403/429）・再取得の無駄を構造的に防ぐ。
+---
+
+# GitHub API Efficient Skill
+
+GitHub API（`gh` CLI / REST / GraphQL）を使う作業の前に、**3つの規律**を強制する:
+
+1. **最安メソッドを選ぶ**（全件取得ではなくサーバー側フィルタ／最小フィールド）
+2. **静的キャッシュを通す**（同じ取得を二度叩かない・再取得でデバッグしない）
+3. **重い・ループする取得の前に budget を確認する**（`gh api rate_limit` は無料）
+
+> このスキルは 2026-06-15 の実事故から正本化した。takeover 中に「現 Sprint の Issue を取得」で十分なところを `gh project item-list -L 4000` で全件（約3,200件）を取得し、さらに自分の Python パースのバグを直すたびに全件を再取得して GraphQL レートリミットを枯渇させた。失敗の核心は分量ではなく **①指示スコープ超過 ②再取得でのバグ修正 ③事前budget未確認**。
+
+## いつ発動するか（必須）
+
+GitHub API を叩く前、特に以下では必ずこのスキルの判断を通す:
+
+- `gh project item-list` / `gh issue list` / `gh search` / `gh api graphql` で **複数件の取得**をする
+- 取得結果を**ループで処理**する、または**繰り返し取得**する見込みがある
+- 「棚卸し」「一覧」「全件」「集計」「Sprint の Issue」などスコープが広い依頼
+
+単発の 1 リソース取得（`gh issue view 123`）や、自明な read 1 回ならこの規律は軽く流してよい。
+
+## 規律1: 最安メソッドを選ぶ
+
+取得の前に「**この問いに答える最小データは何か**」を必ず自問する。詳細な判断フローは
+[reference/method-selection.md](reference/method-selection.md) を参照。要点:
+
+- **指示が切ったスコープを越えない**。「現 Sprint」なら現 Sprint だけ。全件取得は安全ではなく、ただ高コスト
+- **サーバー側でフィルタ**してから取る（`--search` / GraphQL の引数 / `gh issue list --label --milestone --assignee`）。クライアント側 `jq` フィルタのために全件ダンプしない
+- **必要フィールドだけ**取る（`--json number,title` / GraphQL で要る node だけ・`first` は必要数）
+- GraphQL connection は `first`/`last` 必須。`-L 4000` のような巨大ページングを安易に使わない
+- REST GET の繰り返しは ETag 条件付き（304 はレート無料）。GraphQL に ETag は無い → キャッシュ＋最小取得が効く
+
+## 規律2: 静的キャッシュを通す
+
+**同じ取得を二度 API に投げない。** 重い取得結果はまずファイル化し、解析・整形はローカルで反復する。
+パーサのバグ修正のために API を再実行しない（今回の事故の直接原因）。
+
+ラッパー `scripts/gh-cache.sh` を read 系コマンドの前置に使う:
+
+```bash
+# 通常の gh をそのまま前置するだけ。TTL 内の再実行は API ゼロ消費でディスクから返る
+~/.claude/skills/github-api-efficient/scripts/gh-cache.sh \
+  api graphql -f query='{ ... }'
+
+~/.claude/skills/github-api-efficient/scripts/gh-cache.sh \
+  project item-list 35 --owner mationinc --format json > /tmp/board.json
+```
+
+- TTL 既定 300 秒。`GH_CACHE_TTL=60` 等で調整、`GH_CACHE_BYPASS=1` で強制取得（結果は再キャッシュ）
+- write（`--method POST` 等・`mutation`・`issue create` 等）は**キャッシュせず素通し**で `gh` に渡る。安全に前置できる
+- REST GET は ETag を保存し、TTL 切れ時は条件付きリクエストで再検証（304 ならレート無料）
+- 取得結果を解析するなら **`> /tmp/xxx.json` に保存 → ローカルで `jq`/`python`** を反復する。`gh ... | python` の直結を、解析が失敗し得る場面で使わない
+
+ラッパーを使わない場合でも、重い取得は必ず `> file` に保存してから解析する。
+
+## 規律3: 重い取得の前に budget を確認
+
+ループ・一括取得の前に残量を 1 度測り、`件数 × 推定コスト` が残量を超えるなら分割／延期する。
+
+```bash
+# rate_limit endpoint は消費ゼロ。これで事前ゲートする
+gh api rate_limit --jq '{core:.resources.core.remaining, graphql:.resources.graphql.remaining, search:.resources.search.remaining}'
+```
+
+- REST core 既定 5,000 req/h、GraphQL 5,000 pt/h、Search 30 req/min（別バケット）
+- `gh project item-list` / `gh issue list` は GraphQL バケットを消費する
+- 残量が乏しい（例: GraphQL < 200）ときは重い取得を打ち切り、リセット時刻（`x-ratelimit-reset`）まで待つか、スコープを絞る
+- 制限到達（403/429）時は即時 retry 禁止。`retry-after` 優先、無ければ reset まで待機 + 指数バックオフ
+
+仕様の定数・バックオフ詳細は [reference/rate-limits.md](reference/rate-limits.md) を参照。
+
+## 既存資産との関係（scrum-penguin）
+
+scrum-penguin プラグインの `github-operator` エージェントが、scrum バッチ処理向けに同等の
+レートリミット知識と観測ヘルパー `gh-with-budget.sh` を持つ。**接続層は両者とも素の `gh` CLI のみ**で
+競合しない（MCP も独自 HTTP も無い）。本スキルは「main ループの ad-hoc な GitHub 作業」用の規律＋
+キャッシュ層を担い、仕様知識は公式ドキュメントを正本に蒸留している。定数が変わったら両方を更新する。
+
+## チェックリスト（GitHub API 作業の着手前）
+
+- [ ] この取得に必要な**最小スコープ／最小フィールド**は何か即答できる
+- [ ] サーバー側フィルタを使い、全件ダンプ＋クライアント側 filter にしていない
+- [ ] 重い／ループ取得の前に `gh api rate_limit` で残量を確認した
+- [ ] 取得結果は `> file` に保存し、解析はローカルで反復する（再取得しない）
+- [ ] 繰り返し得る read は `gh-cache.sh` を前置した

--- a/private_dot_claude/skills/github-api-efficient/reference/method-selection.md
+++ b/private_dot_claude/skills/github-api-efficient/reference/method-selection.md
@@ -1,0 +1,76 @@
+# 最安メソッド選択ガイド
+
+「この問いに答える最小データは何か」から逆算してメソッドを選ぶ。**取得してからフィルタ**ではなく、
+**フィルタしてから取得**する。
+
+## 判断フロー
+
+```
+何が欲しい？
+├─ 単一リソースの詳細        → gh issue/pr view <n> --json <最小フィールド>
+├─ 条件付きの Issue/PR 一覧   → サーバー側フィルタを最大限使う（下表）
+├─ Project(Board) のフィールド → 現 Sprint 等で絞った GraphQL。全件 item-list は最後の手段
+└─ 集計/横断                  → まずスコープを Sprint/Label/Milestone で絞る
+```
+
+## よくある取得の「高い vs 安い」
+
+| 欲しいもの | ❌ 高い | ✅ 安い |
+|---|---|---|
+| 自分の OPEN Issue | `gh project item-list -L 4000` を `jq` で filter | `gh search issues "repo:o/r is:open assignee:@me"`（Search バケット） |
+| 現 Sprint の Issue | Board 全件取得→client filter | Iteration を GraphQL で 1 度引き、現 Sprint の iterationId で `items(first:N)` を絞る |
+| ラベル別 Issue | 全件→filter | `gh issue list --label X --milestone Y --json number,title` |
+| 1 Issue の Project フィールド | Board 全件 | `gh api graphql` で `node(id:issueId){ ... projectItems(first:5){...fieldValueByName...} }` |
+| PR の状態 | 全 PR list | `gh pr view <n> --json state,reviewDecision,statusCheckRollup` |
+
+## サーバー側フィルタの引き出し
+
+- `gh issue list`: `--label` `--milestone` `--assignee` `--state` `--search` `--json <fields>` `--limit`
+- `gh search issues/prs`: GitHub 検索構文をフルに使う（`repo:` `is:` `label:` `assignee:` `milestone:` `created:`）。**Search は別バケット（30/min）**なので core/graphql を温存できる
+- GraphQL: connection を `first: <必要数>` で絞り、欲しい node だけ書く。`fieldValueByName(name:"Sprint")` のように単一フィールドを名指しで引く
+
+## ⚠ 実測: 全件 item-list は GraphQL 予算の約半分を1回で消費する
+
+2026-06-15 計測（Project #35、約2,300 items、`gh project item-list 35 -L 4000`）:
+
+- **1回のフルボード取得 ≈ 約2,400 GraphQL points**（5,000pt/h 予算の約半分）
+- → **2回で枯渇寸前、3回で完全枯渇**。当初の事故（3回再取得）が枯渇したのは必然
+- さらに**枯渇寸前の状態で取得すると `item-list` が部分的・不完全な結果を返す**（件数が実際より少なく見え、誤った判断を招く）。残量が乏しいときは取得自体を延期する
+
+対策: フルボードは**1回だけ**取得して `> file` にキャッシュし、以降の集計・絞り込みはローカルで行う（`gh-cache.sh` のHITならAPIゼロ）。Sprint やラベルで絞れるなら全件取得を避ける。
+
+## スコープを越えない（最重要）
+
+指示・スキルが切ったスコープより広く取らない。
+
+- 「現 Sprint」と言われたら現 Sprint の iterationId だけ。全 Sprint・全件を取らない
+- 「この Epic 配下」なら sub-issues を辿る。リポ全件を舐めない
+- 全件が**本当に**必要なときだけ全件取得し、その場合は事前 budget 確認＋ページング件数を `log` 的に明示する
+
+## 取得後は保存してローカル反復
+
+重い取得は必ず `> /tmp/xxx.json` に保存し、`jq` / `python` の試行錯誤はそのファイルに対して行う。
+**解析スクリプトのバグを直すために API を再実行しない**（2026-06-15 事故の直接原因）。
+
+```bash
+gh-cache.sh project item-list 35 --owner mationinc --format json > /tmp/board.json
+# 以降、/tmp/board.json に対して jq/python を何度でも回す（API 消費ゼロ）
+jq '...' /tmp/board.json
+python3 analyze.py < /tmp/board.json
+```
+
+## 現 Sprint だけを安く引く例（Project #35）
+
+Board 全件ではなく、Iteration 設定を 1 度引いて現 Sprint を特定し、必要なら絞った items を取る:
+
+```bash
+# 1) iteration 一覧（軽量・1 query）
+gh-cache.sh api graphql -f query='
+{ organization(login:"mationinc"){ projectV2(number:35){
+    field(name:"Sprint"){ ... on ProjectV2IterationField {
+      configuration { iterations { id title startDate duration } } } } } } }'
+# 今日 ∈ [startDate, startDate+duration) の iteration が現 Sprint
+```
+
+`.scrum/.metacache.json` に project_id / field_ids / iteration_ids がキャッシュ済みなら、それを使って
+API 往復をさらに減らせる（field-list の再取得を避ける）。

--- a/private_dot_claude/skills/github-api-efficient/reference/rate-limits.md
+++ b/private_dot_claude/skills/github-api-efficient/reference/rate-limits.md
@@ -1,0 +1,85 @@
+# GitHub API レートリミット仕様（蒸留）
+
+> **正本**: GitHub 公式ドキュメント。値は GitHub 側で変わり得るため、異常時は公式を再確認する。
+> - REST: <https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api>
+> - GraphQL: <https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api>
+> - Secondary: <https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api>
+> - 条件付きリクエスト: <https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate>
+>
+> scrum-penguin プラグインにも並行コピー（`docs/plugin/github-rate-limits.md`）がある。定数を直したら両方更新する。
+
+## 二層構造
+
+GitHub のレートリミットは独立した二層:
+
+- **Primary**: 時間枠クォータ。バケットごとに残量がリセットされる。レスポンスヘッダ `x-ratelimit-*` で観測可
+- **Secondary**: 短時間の乱用防止。明示的な残量 API は無い。間隔・並列・content 作成数で抑制する
+
+## Primary（主要値・認証ユーザー既定）
+
+| バケット | 既定上限 | 備考 |
+|---|---:|---|
+| REST 認証ユーザー | 5,000 req/h | PAT / OAuth。`gh issue create` 等の REST |
+| REST 未認証 | 60 req/h | IP 単位 |
+| GraphQL 認証ユーザー | 5,000 pt/h | **`gh project item-list` / `gh issue list` はここを消費** |
+| Search（REST） | 30 req/min | 別バケット。`gh search` |
+| Actions の GITHUB_TOKEN | 1,000 req(pt)/h/repo | CI 実行時 |
+
+- Enterprise Cloud のユーザー代理は REST 15,000 / GraphQL 10,000 に上がる
+- **残量確認**: `gh api rate_limit`（このendpoint自体は消費ゼロ）。`x-ratelimit-remaining` / `x-ratelimit-reset`（epoch秒）/ `x-ratelimit-resource`
+
+```bash
+gh api rate_limit --jq '{core:.resources.core.remaining, graphql:.resources.graphql.remaining, search:.resources.search.remaining}'
+```
+
+## GraphQL のコストと node 制限
+
+GraphQL は「リクエスト数」ではなく **point** で課金される。さらに Primary 残量があっても **node 制限**が先に当たることがある:
+
+- connection には `first` / `last` が必須（1〜100）
+- 1 call で要求できる総 node 数の上限がある（深い `first:100` の多段ネストで急増）
+- レスポンスに `rateLimit { cost remaining nodeCount }` を含めれば、その call の実コストを観測できる
+
+```graphql
+query { rateLimit { cost remaining nodeCount } ...本体... }
+```
+
+→ **巨大ページング（`-L 4000` 等）や深いネストは、Primary 枯渇・node 制限・timeout のいずれかを引く。** 必要な分だけ `first` で取り、ページングは必要件数で止める。
+
+## Secondary（共有枠・短時間制限）
+
+| 制限 | 値 |
+|---|---|
+| 同時実行（REST+GraphQL 共通） | 100 requests |
+| content 作成（Issue/Comment/PR/Review/Sub-issue 等） | 80 req/min・500 req/h |
+| 単一 endpoint への集中（REST） | 約 900 pt/min |
+| 単一 endpoint への集中（GraphQL） | 約 2,000 pt/min |
+| CPU time | 90 sec / 60 sec window |
+
+### Secondary 用ポイント（リクエスト種別）
+
+| 種別 | ポイント |
+|---|---:|
+| GraphQL query（mutation なし） | 1 |
+| GraphQL mutation を含む | 5 |
+| REST GET / HEAD / OPTIONS（大半） | 1 |
+| REST POST / PATCH / PUT / DELETE（大半） | 5 |
+
+→ 状態取得は query（1pt）に寄せ、書き込みは mutation（5pt）でまとめる。read-only ループに mutation を混ぜない。
+
+## 条件付きリクエスト（ETag）で REST を無料再検証
+
+REST GET のレスポンスには `ETag` ヘッダが付く。次回 `If-None-Match: <etag>` を付けて投げ、変化が無ければ
+**`304 Not Modified` が返り、これは Primary レートリミットを消費しない**。`scripts/gh-cache.sh` がこれを自動化する。
+
+- ETag が効くのは **REST のみ**。GraphQL（`gh project item-list` 等）には ETag が無い → キャッシュ＋最小取得で抑える
+
+## バックオフ（制限到達時）
+
+| 状況 | 対応 |
+|---|---|
+| `403` / `429` で `retry-after` ヘッダあり | その秒数だけ待つ |
+| `x-ratelimit-remaining: 0` | `x-ratelimit-reset`（epoch）まで待つ |
+| 上記以外の二次制限 | 最低 1 分 + 指数バックオフ |
+
+**即時 retry は禁止**（ban を誘発する）。バッチは 1 件ごとに最低 1 秒 + ジッターを入れ、同時実行は低並列に抑える。

--- a/private_dot_claude/skills/github-api-efficient/scripts/executable_gh-cache.sh
+++ b/private_dot_claude/skills/github-api-efficient/scripts/executable_gh-cache.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# gh-cache: TTL disk cache + ETag conditional-request wrapper for read-only `gh` commands.
+#
+# Why: redundant GitHub API calls are the #1 cause of rate-limit exhaustion in ad-hoc
+# work. Re-running the SAME read within TTL is served from disk with ZERO API cost.
+# For REST GET, an expired entry is revalidated with a conditional request; a 304
+# response does NOT count against the primary rate limit.
+#
+# Usage:
+#   gh-cache.sh <gh args...>
+#     gh-cache.sh api rate_limit
+#     gh-cache.sh project item-list 35 --owner mationinc --format json > /tmp/board.json
+#     GH_CACHE_TTL=60 gh-cache.sh issue list --repo o/r --json number,title
+#     GH_CACHE_BYPASS=1 gh-cache.sh ...        # force fresh fetch (still re-caches)
+#
+# Env:
+#   GH_CACHE_DIR     cache dir (default: ${XDG_CACHE_HOME:-~/.cache}/gh-api-cache)
+#   GH_CACHE_TTL     seconds an entry stays fresh (default: 300)
+#   GH_CACHE_BYPASS  =1 to ignore existing cache freshness (still writes/revalidates)
+#
+# Writes (mutations, --method POST/PUT/PATCH/DELETE, create/edit/close/merge/...) and
+# unrecognised subcommands are passed through to `gh` untouched and never cached, so
+# this wrapper is safe to use as a universal prefix.
+#
+# Cache key = hash of the FULL argument vector. So calls that differ only in a
+# client-side `--jq`/`--template` re-fetch instead of reusing one cache entry. For
+# maximum reuse, fetch the RAW response once (no --jq) into a file, then run jq/python
+# against that file locally:
+#   gh-cache.sh project item-list 35 --owner o --format json > /tmp/board.json
+#   jq '...' /tmp/board.json   # repeat freely, zero API cost
+
+set -euo pipefail
+
+CACHE_DIR="${GH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/gh-api-cache}"
+TTL="${GH_CACHE_TTL:-300}"
+BYPASS="${GH_CACHE_BYPASS:-0}"
+SCHEMA="v1"
+WARN_REMAINING=200
+
+if [[ $# -eq 0 ]]; then
+  printf 'usage: gh-cache.sh <gh args...>\n' >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  printf 'gh-cache: ERROR: gh CLI not found in PATH\n' >&2
+  exit 127
+fi
+
+now() { date +%s; }
+
+sha() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+argv=("$@")
+n=$#
+sub="${argv[0]}"
+verb="${argv[1]:-}"
+
+# --- classify the command -------------------------------------------------
+method="GET"
+is_graphql=0
+has_mutation=0
+for ((i = 0; i < n; i++)); do
+  tok="${argv[i]}"
+  case "$tok" in
+    -X | --method)
+      j=$((i + 1))
+      [[ $j -lt $n ]] && method="${argv[j]}"
+      ;;
+    --method=*) method="${tok#--method=}" ;;
+    graphql) is_graphql=1 ;;
+  esac
+  case "$tok" in
+    *mutation*) has_mutation=1 ;;
+  esac
+done
+
+method_uc="$(printf '%s' "$method" | tr '[:lower:]' '[:upper:]')"
+method_read=0
+case "$method_uc" in GET | HEAD | "") method_read=1 ;; esac
+
+# read-only subcommand allowlist
+sub_ok=0
+case "$sub" in
+  api | issue | pr | project | label | search | repo | release) sub_ok=1 ;;
+esac
+
+# for subcommands that have read/write verbs, require a read verb
+read_verb=1
+case "$sub" in
+  issue | pr | project | label | release)
+    case "$verb" in
+      list | view | status | diff | checks | field-list | item-list) read_verb=1 ;;
+      *) read_verb=0 ;;
+    esac
+    ;;
+esac
+
+cacheable=1
+if [[ $has_mutation -eq 1 || $method_read -eq 0 || $sub_ok -eq 0 || $read_verb -eq 0 ]]; then
+  cacheable=0
+fi
+
+# --- pass-through for writes / unknown ------------------------------------
+if [[ $cacheable -eq 0 ]]; then
+  exec gh "$@"
+fi
+
+# --- cache bookkeeping ----------------------------------------------------
+mkdir -p "$CACHE_DIR"
+key="$SCHEMA-$(printf '%s\0' "$@" | sha)"
+body_file="$CACHE_DIR/$key.body"
+meta_file="$CACHE_DIR/$key.meta"
+
+ce_ts=0
+ce_etag=""
+if [[ -f "$meta_file" ]]; then
+  while IFS='=' read -r k v; do
+    case "$k" in
+      ts) ce_ts="$v" ;;
+      etag) ce_etag="$v" ;;
+    esac
+  done <"$meta_file"
+fi
+[[ "$ce_ts" =~ ^[0-9]+$ ]] || ce_ts=0
+
+write_meta() { # $1=ts $2=etag
+  printf 'ts=%s\netag=%s\ncmd=%s\n' "$1" "$2" "${argv[*]}" >"$meta_file"
+}
+
+budget_note() { # $1=header-or-mixed file
+  local rem res
+  rem="$(grep -i '^x-ratelimit-remaining:' "$1" 2>/dev/null | head -n1 | tr -d '\r' | awk -F': ' '{print $2}')"
+  res="$(grep -i '^x-ratelimit-resource:' "$1" 2>/dev/null | head -n1 | tr -d '\r' | awk -F': ' '{print $2}')"
+  if [[ "$rem" =~ ^[0-9]+$ ]] && ((rem < WARN_REMAINING)); then
+    printf 'gh-cache: WARN rate budget low (resource=%s remaining=%s)\n' "${res:-unknown}" "$rem" >&2
+  fi
+}
+
+strip_headers() { # stdin: `gh api -i` output -> stdout: body only
+  awk 'b{sub(/\r$/,"");print;next} /^[[:space:]]*$/{b=1}'
+}
+
+# --- fresh cache hit ------------------------------------------------------
+age=$(($(now) - ce_ts))
+if [[ "$BYPASS" != "1" && -f "$body_file" && $ce_ts -gt 0 && $age -lt $TTL ]]; then
+  printf 'gh-cache: HIT (age=%ss ttl=%ss) %s %s\n' "$age" "$TTL" "$sub" "$verb" >&2
+  cat "$body_file"
+  exit 0
+fi
+
+# --- REST GET path: use -i to capture ETag, revalidate when possible ------
+if [[ "$sub" == "api" && $is_graphql -eq 0 && $method_read -eq 1 ]]; then
+  tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' EXIT
+  cond=()
+  if [[ -n "$ce_etag" && -f "$body_file" ]]; then
+    cond=(-H "If-None-Match: $ce_etag")
+  fi
+  if gh api -i "${cond[@]}" "${argv[@]:1}" >"$tmp" 2>/dev/null; then
+    rc=0
+  else
+    rc=$?
+  fi
+  status="$(head -n1 "$tmp" | tr -d '\r' | awk '{print $2}')"
+
+  if [[ "$status" == "304" && -f "$body_file" ]]; then
+    write_meta "$(now)" "$ce_etag"
+    printf 'gh-cache: 304 revalidated free (was %ss old) api\n' "$age" >&2
+    budget_note "$tmp"
+    cat "$body_file"
+    exit 0
+  fi
+
+  if [[ "$status" == "200" ]]; then
+    new_etag="$(grep -i '^etag:' "$tmp" | head -n1 | tr -d '\r' | awk -F': ' '{print $2}')"
+    strip_headers <"$tmp" >"$body_file"
+    write_meta "$(now)" "$new_etag"
+    printf 'gh-cache: MISS stored (api)\n' >&2
+    budget_note "$tmp"
+    cat "$body_file"
+    exit 0
+  fi
+
+  # unexpected status (or 304 with no body on disk): fall back to a plain call
+  # so the real error/output surfaces to the caller. rm tmp explicitly because
+  # `exec` replaces the process and the EXIT trap would not fire.
+  printf 'gh-cache: passthrough (api status=%s)\n' "${status:-?}" >&2
+  rm -f "$tmp"
+  exec gh "$@"
+fi
+
+# --- GraphQL / gh subcommand path: plain fetch + TTL cache (no ETag) -------
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+if gh "$@" >"$tmp"; then
+  rc=0
+else
+  rc=$?
+fi
+
+if [[ $rc -eq 0 && -s "$tmp" ]]; then
+  cp "$tmp" "$body_file"
+  write_meta "$(now)" "$ce_etag"
+  printf 'gh-cache: MISS stored (%s %s)\n' "$sub" "$verb" >&2
+else
+  printf 'gh-cache: not cached (rc=%s, empty=%s)\n' "$rc" "$([[ -s "$tmp" ]] && echo no || echo yes)" >&2
+fi
+
+cat "$tmp"
+exit "$rc"

--- a/private_dot_claude/skills/github-api-efficient/scripts/executable_gh-cache.sh
+++ b/private_dot_claude/skills/github-api-efficient/scripts/executable_gh-cache.sh
@@ -30,6 +30,7 @@
 #   jq '...' /tmp/board.json   # repeat freely, zero API cost
 
 set -euo pipefail
+umask 077  # cache may hold private-repo API responses; keep cache files owner-only
 
 CACHE_DIR="${GH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/gh-api-cache}"
 TTL="${GH_CACHE_TTL:-300}"
@@ -121,12 +122,15 @@ meta_file="$CACHE_DIR/$key.meta"
 ce_ts=0
 ce_etag=""
 if [[ -f "$meta_file" ]]; then
+  # Read only the first two lines (ts, etag). The cmd line written by write_meta
+  # can contain newlines (e.g. multi-line GraphQL queries); reading it here would
+  # let an embedded "ts="/"etag=" line override the real values.
   while IFS='=' read -r k v; do
     case "$k" in
       ts) ce_ts="$v" ;;
       etag) ce_etag="$v" ;;
     esac
-  done <"$meta_file"
+  done < <(head -n2 "$meta_file")
 fi
 [[ "$ce_ts" =~ ^[0-9]+$ ]] || ce_ts=0
 
@@ -136,8 +140,8 @@ write_meta() { # $1=ts $2=etag
 
 budget_note() { # $1=header-or-mixed file
   local rem res
-  rem="$(grep -i '^x-ratelimit-remaining:' "$1" 2>/dev/null | head -n1 | tr -d '\r' | awk -F': ' '{print $2}')"
-  res="$(grep -i '^x-ratelimit-resource:' "$1" 2>/dev/null | head -n1 | tr -d '\r' | awk -F': ' '{print $2}')"
+  rem="$(grep -i '^x-ratelimit-remaining:' "$1" 2>/dev/null | head -n1 | tr -d '\r' | awk -F': ' '{print $2}' || true)"
+  res="$(grep -i '^x-ratelimit-resource:' "$1" 2>/dev/null | head -n1 | tr -d '\r' | awk -F': ' '{print $2}' || true)"
   if [[ "$rem" =~ ^[0-9]+$ ]] && ((rem < WARN_REMAINING)); then
     printf 'gh-cache: WARN rate budget low (resource=%s remaining=%s)\n' "${res:-unknown}" "$rem" >&2
   fi
@@ -179,7 +183,7 @@ if [[ "$sub" == "api" && $is_graphql -eq 0 && $method_read -eq 1 ]]; then
   fi
 
   if [[ "$status" == "200" ]]; then
-    new_etag="$(grep -i '^etag:' "$tmp" | head -n1 | tr -d '\r' | awk -F': ' '{print $2}')"
+    new_etag="$(grep -i '^etag:' "$tmp" 2>/dev/null | head -n1 | tr -d '\r' | awk -F': ' '{print $2}' || true)"
     strip_headers <"$tmp" >"$body_file"
     write_meta "$(now)" "$new_etag"
     printf 'gh-cache: MISS stored (api)\n' >&2
@@ -205,12 +209,21 @@ else
   rc=$?
 fi
 
-if [[ $rc -eq 0 && -s "$tmp" ]]; then
+# gh api graphql returns HTTP 200 + {"errors":[...]} with rc=0 on query errors.
+# Caching that would serve the error payload for the whole TTL, so detect and skip it.
+graphql_err=0
+if [[ $is_graphql -eq 1 ]] && command -v jq >/dev/null 2>&1; then
+  if jq -e 'has("errors") and (.errors | length > 0)' "$tmp" >/dev/null 2>&1; then
+    graphql_err=1
+  fi
+fi
+
+if [[ $rc -eq 0 && -s "$tmp" && $graphql_err -eq 0 ]]; then
   cp "$tmp" "$body_file"
   write_meta "$(now)" "$ce_etag"
   printf 'gh-cache: MISS stored (%s %s)\n' "$sub" "$verb" >&2
 else
-  printf 'gh-cache: not cached (rc=%s, empty=%s)\n' "$rc" "$([[ -s "$tmp" ]] && echo no || echo yes)" >&2
+  printf 'gh-cache: not cached (rc=%s, empty=%s, graphql_err=%s)\n' "$rc" "$([[ -s "$tmp" ]] && echo no || echo yes)" "$graphql_err" >&2
 fi
 
 cat "$tmp"


### PR DESCRIPTION
## 概要

GitHub API（`gh` CLI / REST / GraphQL）を使う作業の前に通す**グローバル規律スキル** `github-api-efficient` を追加します。

ad-hoc な GitHub 取得作業でレートリミット（GraphQL 5,000pt/h）を枯渇させた実事故を受けて整備しました。失敗の核心は分量ではなく **①指示スコープ超過 ②再取得でのバグ修正 ③事前 budget 未確認** の3点でした。

### 構成

| ファイル | 役割 |
|---|---|
| `SKILL.md` | 3規律（最安メソッド選択 / 静的キャッシュ / 事前 budget 確認）と発動条件・チェックリスト |
| `reference/rate-limits.md` | レートリミット仕様の蒸留（Primary/Secondary 定数・GraphQL point/node・ETag・バックオフ）。公式 doc を正本に |
| `reference/method-selection.md` | 「高い vs 安い」取得の判断ガイド。実測コスト（#35 フルボード ≈ 約2,400 GraphQL points/回）を明記 |
| `scripts/gh-cache.sh` | TTL ディスクキャッシュ＋ETag 条件付きリクエストのラッパー。write は素通し |

### 設計判断

- scrum-penguin プラグインの `github-operator`（バッチ処理用）とは**棲み分け**。接続層は両者とも素の `gh` CLI のみで競合なし。本スキルは「main ループの ad-hoc 作業」用
- 強制力は **skill のみ**（運用して足りなければ後から PreToolUse hook へ拡張可能）

## テスト計画

実リソースで検証済み（すべてパス）:

- bash 構文 OK / `shellcheck` クリーン
- **MISS→保存** / **同一コマンド再実行→HIT（API ゼロ消費）** / **BYPASS時→304 で無料再検証（REST core 非消費）**
- フルボード取得を1回キャッシュ→ローカルで複数回集計（budget 不変）を実証
- 実測: `gh project item-list 35 -L 4000`（約2,300 items）が1回で約2,400 GraphQL points を消費することを定量確認 → 全件ダンプ回避とキャッシュの根拠に


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * GitHub API 利用効率化に関する新しい規律スキルドキュメントとリファレンスガイドを追加。メソッド選択、レートリミット仕様、キャッシュ戦略について整理。

* **Chores**
  * GitHub API 読取り操作向けの TTL 付きディスクキャッシュラッパースクリプトを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->