### PR TITLE
fix(gitconfig): render coderabbit machineId from machine-id file

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -23,3 +23,8 @@
 [commit]
 	gpgsign = true
 {{- end }}
+{{- $machineId := joinPath .chezmoi.homeDir ".coderabbit" "machine-id" }}
+{{- if stat $machineId }}
+[coderabbit]
+	machineId = {{ output "cat" $machineId | trim }}
+{{- end }}


### PR DESCRIPTION
## 概要

CodeRabbit CLI がグローバル gitconfig に書き込む `[coderabbit] machineId` が chezmoi ソースに無いため、`chezmoi diff` が常に差分ありになっていた。この machineId は認証情報ではなくマシン固有の識別子（本物の認証は `~/.coderabbit/auth.json`、dotfiles 管理外）。

## 変更内容

- `dot_gitconfig.tmpl` に `[coderabbit]` セクションを追加し、値は各マシンの `~/.coderabbit/machine-id` から apply 時に解決する（`stat` でファイル存在をガード）。
- リポジトリには machineId の実値を焼き込まない（テンプレート式のみ）。各マシンが自分の値にレンダリングする。

## テスト計画

- [x] `chezmoi cat ~/.gitconfig` で `[coderabbit] machineId` が実値にレンダリングされることを確認
- [x] `chezmoi diff` がクリーン（空）になることを確認
- [ ] CodeRabbit CLI 未導入の新マシンでは `[coderabbit]` セクションが出力されないこと（`stat` ガード）

## 補足

- machine-id ファイルが無い新マシンではセクションごと省略され、CodeRabbit CLI 初回実行後に再度 `chezmoi apply` すれば追従する。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Git設定にCodeRabbit機械ID設定が条件付きで自動追加されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->