### PR TITLE
feat: Ghostty の foreground 色を明るめに調整 (#dde0e8)

### DIFF
--- a/dot_config/ghostty/config.tmpl
+++ b/dot_config/ghostty/config.tmpl
@@ -30,7 +30,7 @@ background-image-repeat = false
 
 # --- Iceberg phantom colors ---
 background = #161821
-foreground = #c5c8d0
+foreground = #dde0e8
 cursor-color = #c5c8d0
 cursor-text = #161821
 selection-background = #272b41


### PR DESCRIPTION
## 概要

Ghostty の foreground 色を `#c5c8d0` → `#dde0e8` にやや明るく調整する（Iceberg phantom テーマの可読性微調整）。

変更は `dot_config/ghostty/config.tmpl` の 1 行のみ。背景・カーソル・選択色等は変更なし。

## テスト計画

- [x] `chezmoi diff` で意図した 1 行（foreground のみ）の変更であることを確認
- [x] `chezmoi apply` で `~/.config/ghostty/config` に反映され、テンプレート展開が壊れないことを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* **テーマカラー更新** - Iceberg phantom テーマの前景色（テキスト表示色）を調整しました。より調和した配色となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->