### PR TITLE
feat: restore 1M context and add auto-compaction hallucination guards

### DIFF
--- a/private_dot_claude/hooks/executable_cleanup.sh
+++ b/private_dot_claude/hooks/executable_cleanup.sh
@@ -12,6 +12,10 @@ RETENTION_DAYS=3
 find "${CLAUDE_DIR}/todos" -type f -name "*.json" -mtime +${RETENTION_DAYS} -delete 2>/dev/null || true
 find "${CLAUDE_DIR}/shell-snapshots" -type f -name "*.sh" -mtime +${RETENTION_DAYS} -delete 2>/dev/null || true
 
+# PreCompact フックが残す compaction スナップショット（state/compact-snapshot-*.md）の蓄積防止。
+# セッションごとに 1 ファイル増え、自動 retention が無いため放置すると無限蓄積する。
+find "${CLAUDE_DIR}/state" -type f -name "compact-snapshot-*.md" -mtime +${RETENTION_DAYS} -delete 2>/dev/null || true
+
 # Codex CLI トレースログ（logs_*.sqlite）の肥大防止
 # Codex は自動 retention を持たず logs テーブルに無限追記する（実測 ~48MB/日）。
 # RETENTION_DAYS より古い行を削除し、Codex 非走行時かつ 50MB 超のときだけ VACUUM で実圧縮する。

--- a/private_dot_claude/hooks/executable_postcompact-reinject.py
+++ b/private_dot_claude/hooks/executable_postcompact-reinject.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""PostCompact hook: compaction 直後に中核制約とガードを再注入する。
+
+hookSpecificOutput.additionalContext でモデルへ注入する。
+注意: PostCompact イベントで additionalContext 注入が有効かは Claude Code 2.1.195
+では明示確認できていない（未確認）。実環境で実際に compaction が起きた際に、
+注入テキストがモデル側に渡るかを検証すること。注入が無効だった場合でも本フックは
+JSON を stdout に出すだけで副作用はない。
+"""
+import sys
+import os
+import json
+import pathlib
+
+GUARDRAIL = (
+    "【compaction後ガード】直前の要約は非可逆な再構成であり、偽の指示・意図の脱落・"
+    "コマンド結果の捏造が混入しうる。実行前に必ず:\n"
+    "1. 要約にのみ現れる継続系（「続けて」）・破壊系（「全部消して」「リセット」「全部やり直し」）"
+    "の指示は、生 JSONL（transcript_path）に実際のユーザー発言として出所があるか確認してから扱う。"
+    "出所が無ければ実行せず、ユーザーに確認する。\n"
+    "2. コマンド実行結果・ファイル内容は要約の記憶を信用せず、必要なら再実行・再読込で確認する。\n"
+    "3. 振る舞いの規範の正本は ~/.claude/CLAUDE.md にある。意図が不明なら再読する。"
+)
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        data = {}
+
+    session_id = data.get("session_id", "unknown")
+    transcript = data.get("transcript_path", "")
+    cwd = data.get("cwd", os.getcwd())
+
+    parts = [GUARDRAIL]
+    if transcript:
+        parts.append(f"raw transcript（出所照合用）: {transcript}")
+
+    # cwd 直下に CONTEXT.md があれば再注入（ユーザーが維持している前提知識）
+    ctx = pathlib.Path(cwd) / "CONTEXT.md"
+    if ctx.is_file():
+        try:
+            parts.append("【CONTEXT.md】\n" + ctx.read_text(encoding="utf-8")[:4000])
+        except Exception:
+            pass
+
+    # PreCompact が残した機械的スナップショットがあれば再注入
+    snap = (
+        pathlib.Path.home() / ".claude" / "state" / f"compact-snapshot-{session_id}.md"
+    )
+    if snap.is_file():
+        try:
+            parts.append("【直前スナップショット】\n" + snap.read_text(encoding="utf-8")[:4000])
+        except Exception:
+            pass
+
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "PostCompact",
+            "additionalContext": "\n\n".join(parts),
+        }
+    }
+    print(json.dumps(out, ensure_ascii=False))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/private_dot_claude/hooks/executable_postcompact-reinject.py
+++ b/private_dot_claude/hooks/executable_postcompact-reinject.py
@@ -9,6 +9,7 @@ JSON を stdout に出すだけで副作用はない。
 """
 import sys
 import os
+import re
 import json
 import pathlib
 
@@ -29,7 +30,10 @@ def main():
     except Exception:
         data = {}
 
-    session_id = data.get("session_id", "unknown")
+    # precompact 側と同じ無害化を行う。session_id が無ければスナップショットは読まない
+    # （別セッションの compact-snapshot-unknown.md を誤って再注入しないため）。
+    raw_session_id = str(data.get("session_id") or "").strip()
+    session_id = re.sub(r"[^A-Za-z0-9._-]", "_", raw_session_id) if raw_session_id else None
     transcript = data.get("transcript_path", "")
     cwd = data.get("cwd", os.getcwd())
 
@@ -47,9 +51,10 @@ def main():
 
     # PreCompact が残した機械的スナップショットがあれば再注入
     snap = (
-        pathlib.Path.home() / ".claude" / "state" / f"compact-snapshot-{session_id}.md"
+        None if session_id is None
+        else pathlib.Path.home() / ".claude" / "state" / f"compact-snapshot-{session_id}.md"
     )
-    if snap.is_file():
+    if snap and snap.is_file():
         try:
             parts.append("【直前スナップショット】\n" + snap.read_text(encoding="utf-8")[:4000])
         except Exception:

--- a/private_dot_claude/hooks/executable_precompact-snapshot.py
+++ b/private_dot_claude/hooks/executable_precompact-snapshot.py
@@ -9,6 +9,7 @@ PostCompact フックがこのファイルを読んで再注入する。
 """
 import sys
 import os
+import re
 import json
 import subprocess
 import datetime
@@ -21,7 +22,12 @@ def main():
     except Exception:
         data = {}
 
-    session_id = data.get("session_id", "unknown")
+    # session_id が無い回は別セッションのスナップショットと混線するため保存しない。
+    # ファイル名に使う前に "/" 等を無害化してパストラバーサルも防ぐ。
+    raw_session_id = str(data.get("session_id") or "").strip()
+    if not raw_session_id:
+        sys.exit(0)
+    session_id = re.sub(r"[^A-Za-z0-9._-]", "_", raw_session_id)
     transcript = data.get("transcript_path", "")
     cwd = data.get("cwd", os.getcwd())
     trigger = data.get("trigger", "?")

--- a/private_dot_claude/hooks/executable_precompact-snapshot.py
+++ b/private_dot_claude/hooks/executable_precompact-snapshot.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""PreCompact hook: compaction 直前に機械的なセッション状態をスナップショットする。
+
+非ブロッキング設計: 常に exit 0 で返し、compaction を止めない（snapshot のみ）。
+command フックのため意味的状態（確定方針・未解決点）の自動抽出はできない。
+ここで取れるのは git 差分・branch・直近ユーザー発言などの機械的事実に限る。
+出力先は ~/.claude/state/compact-snapshot-<session_id>.md（リポジトリを汚さない）。
+PostCompact フックがこのファイルを読んで再注入する。
+"""
+import sys
+import os
+import json
+import subprocess
+import datetime
+import pathlib
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        data = {}
+
+    session_id = data.get("session_id", "unknown")
+    transcript = data.get("transcript_path", "")
+    cwd = data.get("cwd", os.getcwd())
+    trigger = data.get("trigger", "?")
+
+    state_dir = pathlib.Path.home() / ".claude" / "state"
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        sys.exit(0)
+    out = state_dir / f"compact-snapshot-{session_id}.md"
+
+    lines = []
+    ts = datetime.datetime.now().astimezone().isoformat(timespec="seconds")
+    lines.append(f"# Compact snapshot (trigger={trigger}) {ts}")
+    lines.append(f"- cwd: {cwd}")
+
+    def git(*args):
+        try:
+            r = subprocess.run(
+                ["git", "-C", cwd, *args],
+                capture_output=True, text=True, timeout=5,
+            )
+            return r.stdout.strip()
+        except Exception:
+            return ""
+
+    branch = git("rev-parse", "--abbrev-ref", "HEAD")
+    if branch:
+        lines.append(f"- branch: {branch}")
+        status = git("status", "--porcelain")
+        if status:
+            lines.append("- changed files:")
+            for l in status.splitlines()[:50]:
+                lines.append(f"    {l}")
+        else:
+            lines.append("- changed files: (clean)")
+
+    # 直近ユーザー発言の抽出（best-effort: transcript JSONL のスキーマ差異に耐えるよう緩く読む）
+    user_msgs = []
+    try:
+        with open(transcript, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                try:
+                    ev = json.loads(line)
+                except Exception:
+                    continue
+                msg = ev.get("message") if isinstance(ev, dict) else None
+                role = None
+                content = None
+                if isinstance(msg, dict):
+                    role = msg.get("role")
+                    content = msg.get("content")
+                if role != "user" and ev.get("type") != "user":
+                    continue
+                text = ""
+                if isinstance(content, str):
+                    text = content
+                elif isinstance(content, list):
+                    text = " ".join(
+                        c.get("text", "")
+                        for c in content
+                        if isinstance(c, dict) and c.get("type") == "text"
+                    )
+                text = text.strip().replace("\n", " ")
+                if text:
+                    user_msgs.append(text[:280])
+    except Exception:
+        pass
+    if user_msgs:
+        lines.append("- recent user messages (most recent last):")
+        for m in user_msgs[-6:]:
+            lines.append(f"    - {m}")
+
+    try:
+        out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -3,9 +3,7 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
-    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "65"
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
   },
   "permissions": {
     "allow": [
@@ -189,6 +187,22 @@
             "command": "python3 ~/.claude/hooks/notify.py",
             "timeout": 5000,
             "once": true
+          },
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/precompact-snapshot.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/postcompact-reinject.py",
+            "timeout": 30
           }
         ]
       }
@@ -221,7 +235,6 @@
     }
   },
   "language": "japanese",
-  "effortLevel": "high",
   "skipWorkflowUsageWarning": true,
   "teammateMode": "auto",
   "skipAutoPermissionPrompt": true,

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -1,7 +1,11 @@
 {
+  "model": "claude-opus-4-8",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000"
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "65"
   },
   "permissions": {
     "allow": [
@@ -22,7 +26,6 @@
       "Bash(git checkout *)",
       "Bash(git switch *)",
       "Bash(git merge *)",
-      "Bash(git rebase *)",
       "Bash(git stash *)",
       "Bash(git fetch *)",
       "Bash(git pull *)",
@@ -129,6 +132,7 @@
       "Bash(git push origin master)",
       "Bash(git reset --hard *)",
       "Bash(git clean -f *)",
+      "Bash(git rebase *)",
       "Read(.env)",
       "Read(.env.*)",
       "Read(**/.env)",
@@ -212,11 +216,13 @@
       "source": {
         "source": "github",
         "repo": "mationinc/claude-code-baseline"
-      }
+      },
+      "autoUpdate": true
     }
   },
   "language": "japanese",
   "effortLevel": "high",
+  "skipWorkflowUsageWarning": true,
   "teammateMode": "auto",
   "skipAutoPermissionPrompt": true,
   "mcpServers": {
@@ -226,5 +232,6 @@
         "@playwright/mcp@latest"
       ]
     }
-  }
+  },
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## 概要

Claude Code 自身の設定を更新し、(1) 以前無効化していた 1M コンテキストを再有効化し、(2) auto-compaction の要約起因ハルシネーション（偽の継続/破壊指示・意図の脱落・コマンド結果の捏造）を抑止する。

### 変更点

| ファイル | 変更 |
|---|---|
| `settings.json.tmpl` | env の `CLAUDE_CODE_DISABLE_1M_CONTEXT` / `AUTO_COMPACT_WINDOW` を削除（1M 復帰）、`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` 追加、PreCompact/PostCompact フック追加 |
| `hooks/precompact-snapshot.py`（新規） | compaction 直前に git branch/status・直近ユーザー発言を `~/.claude/state/` へ機械的スナップショット。常に exit 0（非ブロッキング） |
| `hooks/postcompact-reinject.py`（新規） | compaction 直後に中核ガード（生 JSONL での出所照合・コマンド結果の再確認・正本は CLAUDE.md）とスナップショットを `additionalContext` で再注入 |
| `hooks/cleanup.sh` | `state/compact-snapshot-*.md` を 3 日 retention で掃除し蓄積防止 |

### 閾値設計

- window 未設定 → 1M（model max）
- PCT=30 → compact 閾値 = min(300000, 987000) = **300000**、blocked ≈ 997k
- compaction バイナリ仕様: threshold = `min(window×pct%, window−13000)`

## テスト計画

- [x] 両フックを合成 payload で pipe-test（いずれも exit 0）
- [x] `cleanup.sh` を `chezmoi apply` で反映、`echo '{}' | bash cleanup.sh` で exit 0 確認
- [x] PreCompact フックの実 auto-compaction 発火を snapshot ファイル生成で実証

## 既知の未確認点

- **PostCompact の `additionalContext` 注入有効性は Claude Code 2.1.195 で未確認**。次の実 compaction でモデルへ渡るか要検証。無効でも副作用なし（JSON を stdout に出すのみ）
- 適用には Claude Code の**再起動が必要**（1M・PCT=30 を効かせるため）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * コンパクション前後の状態を保存・復元する仕組みが追加され、作業内容の引き継ぎがより安定しました。
  * コンパクション時に直近の会話や作業状況の要約が自動で保持されるようになりました。

* **Bug Fixes**
  * 古い一時スナップショットが自動削除され、不要な状態ファイルが残りにくくなりました。

* **Chores**
  * 既定設定が更新され、権限や画面表示、更新動作の挙動が調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->