### PR TITLE
review-pr スキルに CI チェック失敗の検知・修正手順を追加

### DIFF
--- a/private_dot_claude/skills/review-pr/SKILL.md
+++ b/private_dot_claude/skills/review-pr/SKILL.md
@@ -188,7 +188,7 @@ After processing all threads, display a summary table:
 
 ### CI Checks
 - ✅ lint: passed
-- ❌ test: failed (flaky — reran via `gh run rerun`)
+- ❌ test: failed (flaky — rerun proposed via `gh run rerun`)
 - ❌ build: failed (type error) — fixed in <commit-hash>
 
 ### Addressed

--- a/private_dot_claude/skills/review-pr/SKILL.md
+++ b/private_dot_claude/skills/review-pr/SKILL.md
@@ -11,7 +11,37 @@ Respond to PR review comments, including CodeRabbit automated reviews and human 
 
 ## Procedure
 
-### 1. Fetch Review Threads (GraphQL API)
+### 1. Check CI Status
+
+```bash
+gh pr checks <pr_number>
+```
+
+- Do not use `--watch`. Poll explicitly (re-run the command) if checks are still pending
+- If any check has failed, find the workflow run and fetch failure logs:
+  ```bash
+  gh run list --branch <branch> --limit 5
+  gh run view <run-id> --log-failed
+  ```
+- If all checks pass, skip to step 3 (Fetch Review Threads)
+
+### 2. Classify & Handle CI Failures
+
+Classify each failure using the failed logs from step 1:
+
+| Category | Examples | Handling |
+|----------|----------------------------------|-----------------------------------------------|
+| ① Lint / format | ESLint, markdownlint, Prettier | Mechanically fixable — identify the fix and apply it |
+| ② Test failure | Unit / integration test failure | Needs root-cause analysis — do not auto-fix |
+| ③ Build / type error | Compile error, type check failure | Identify the fix and apply it |
+| ④ Infra / flaky | Runner failure, network timeout | Propose `gh run rerun <run-id>` (add `--failed` to retry only failed jobs) |
+
+- **① and ③**: identify and apply the fix. Who executes the fix (yourself vs. delegate) follows `~/.claude/skills/task-delegation/SKILL.md` — this skill does not duplicate that decision table
+- **②**: report the root cause and a proposed fix in the final summary; do not auto-fix
+- **④**: propose `gh run rerun <run-id>` instead of touching code
+- Fixes from ① and ③ are committed and pushed together with review-comment fixes in step 6 (Commit & Push)
+
+### 3. Fetch Review Threads (GraphQL API)
 
 ```bash
 gh api graphql -f query='
@@ -42,7 +72,7 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 - Derive owner/repo from `gh repo view --json owner,name`
 - PR number from `$ARGUMENTS` or current branch's PR: `gh pr view --json number`
 
-### 2. Classify Comments
+### 4. Classify Comments
 
 **Skip** resolved threads (`isResolved: true`).
 
@@ -61,7 +91,7 @@ For unresolved threads, classify by source and severity:
 - `🟡` or "Minor" → Minor
 - `🛠️` or "Suggestion" → Suggestion
 
-### 3. Fix Code
+### 5. Fix Code
 
 For each actionable comment:
 1. Read the referenced file and line
@@ -69,15 +99,16 @@ For each actionable comment:
 3. Apply the fix
 4. Verify official documentation for SDK/API-related suggestions before applying
 
-### 4. Commit & Push
+### 6. Commit & Push
 
 Follow the `/commit` and `/push` skill workflows:
 - Stage specific files only
-- Use `fix: address review feedback` or similar Conventional Commits message
+- Use `fix: address review feedback` or similar Conventional Commits message (include CI fixes from step 2 in the same commit if they touch the same files, otherwise split logically)
 - Include Co-Authored-By trailer
 - Push to the current branch
+- After pushing, CI reruns automatically — no need to manually re-check unless the summary requires confirmed-green status
 
-### 5. Reply to Review Threads (GraphQL API)
+### 7. Reply to Review Threads (GraphQL API)
 
 #### Reply language rules
 
@@ -147,12 +178,17 @@ Out of scope for the current PR. Tracked in #<issue-number>.
 📝 <日本語の修正内容の要約>
 ```
 
-### 6. Output Summary
+### 8. Output Summary
 
 After processing all threads, display a summary table:
 
 ```
 ## Review Response Summary
+
+### CI Checks
+- ✅ lint: passed
+- ❌ test: failed (flaky — reran via `gh run rerun`)
+- ❌ build: failed (type error) — fixed in <commit-hash>
 
 ### Addressed
 - [file:line] <description> (commit: <hash>)
@@ -164,6 +200,8 @@ After processing all threads, display a summary table:
 - <count> threads
 ```
 
+- The CI Checks section lists every check name, its result, its category from step 2, and the action taken (fixed / reported / rerun proposed)
+
 ## Best Practices
 
 - **All threads must be resolved** — every review thread must end in a resolved state after processing
@@ -171,3 +209,4 @@ After processing all threads, display a summary table:
 - Include commit hashes in replies so reviewers can verify fixes
 - Verify SDK/API suggestions against official documentation before applying
 - **Out-of-scope items must have a tracking Issue** — always create an Issue before deferring, then resolve the thread with the Issue link
+- **CI failures must not be silently ignored** — even when CodeRabbit and human reviewers raise no comments, a failing check (e.g. lint errors CodeRabbit did not flag) must be caught in step 1 and either fixed or reported in the summary

--- a/private_dot_claude/skills/review-pr/SKILL.md
+++ b/private_dot_claude/skills/review-pr/SKILL.md
@@ -17,6 +17,7 @@ Respond to PR review comments, including CodeRabbit automated reviews and human 
 gh pr checks <pr_number>
 ```
 
+- `<pr_number>` is obtained the same way as in step 3 (Fetch Review Threads): from `$ARGUMENTS` or `gh pr view --json number`
 - Do not use `--watch`. Poll explicitly (re-run the command) if checks are still pending
 - If any check has failed, find the workflow run and fetch failure logs:
   ```bash


### PR DESCRIPTION
## 概要

PR レビュー対応の手順書（`private_dot_claude/skills/review-pr/SKILL.md`、`review-pr` スキル本体）に、CI チェック失敗を検知して対応する手順を追加します。

これまでの `review-pr` はレビュースレッド（CodeRabbit のコメント、人間のレビュー）への対応だけを行っていました。CodeRabbit が指摘しない箇所で CI の lint チェックが失敗していても、そのまま見落としていました。

今回の変更で、手順の先頭に次のステップを追加します。

- CI チェックの状態を確認する（`gh pr checks`、`--watch` は使わず明示ポーリング）
- 失敗があれば `gh run view <run-id> --log-failed` でログを取得する
- 失敗を 4 種類に分類する（① lint / format ② テスト失敗 ③ build / 型エラー ④ infra / flaky）
- ①③ は修正内容を特定して対応する（修正の実行主体は `task-delegation` スキルの判定に従い、判定表はここでは重複させない）
- ② は原因分析と修正案をサマリに報告する（自動修正はしない）
- ④ は `gh run rerun` の実行を提案する
- 最終サマリに「CI Checks」の節を追加し、チェック名・結果・分類・対応内容を記載する

既存のレビュースレッド対応の手順（ステップ番号）は、この追加に合わせて振り直しています。内容自体は変更していません。

## テスト計画

- [x] `git diff --stat` で変更ファイルが `private_dot_claude/skills/review-pr/SKILL.md` の 1 件のみであることを確認
- [ ] 次回、実際の PR に対して `review-pr` スキルを実行し、CI チェック確認のステップが手順どおりに動くことを確認する（ドキュメント変更のため、自動テストは対象外）

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * CI確認手順（再実行条件、失敗時のログ取得）と、失敗ログに基づくカテゴリ分類・対応方針を整理しました。
  * レビュースレッドの扱い（解決済みのスキップ、未解決の判断基準）を更新し、対応要否を表形式で明確化しました。
  * 出力サマリーにCIチェック結果欄を追加し、見落としを防ぐ運用（サイレント未対応の捕捉、スコープ外の追跡）と修正→コミット/プッシュ手順を拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->