### PR TITLE
settings.json: 1M コンテキスト無効化と effort=medium 固定、auto-compact 整合

### DIFF
--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -1,9 +1,34 @@
 {
   "model": "claude-opus-4-8",
+  {{/*
+    effort は medium で固定する。理由: Opus 4.8 + 1M context + high effort が
+    Case B（tool_use ブロック欠落）の既知高リスク構成であり、下の 1M 無効化と
+    セットで effort も落とすのが HANDOVER-tool-fabrication-2026-06-19.md の意図。
+    個別セッションで負荷の高い作業をするときは `/effort high` で一時的に上げられる。
+  */}}
+  "effortLevel": "medium",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
+    {{/*
+      1M コンテキストは無効化する。model 名は Opus のまま（~/.claude は Opus 用
+      config、Fable パイロットは別 config dir）で、1M の on/off はこの env 変数で
+      制御する。無効化の理由: Opus 4.8 + 1M + extended thinking + 長時間セッションが
+      ツール結果・偽ユーザーターンの捏造（Case B / anthropics/claude-code#69015 等）を
+      誘発する既知の高リスク構成であり、コスト・安定性リスクが常用のメリットを上回るため。
+      再有効化してよい条件: Fable 5 等で長大コンテキストが実際に必要になり、その構成で
+      安定性を実測確認できた場合のみ。
+    */}}
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
+    {{/*
+      以下 2 つの auto-compact 設定は 1M 無効化（= 200k コンテキスト運用）に整合させた値。
+      WINDOW=200000・PCT=65 で概ね 130k 到達時に compact が発火する。
+      PCT=30 は 1M 有効（大コンテキスト）を前提にした値で、200k 運用のままだと約 60k で
+      compact が発火し早すぎる。1M 無効化と PCT はセットの依存関係にあるため、1M を戻す
+      場合はこの 2 値も 1M 前提（PCT=30・WINDOW 撤去）に合わせて見直すこと。
+    */}}
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "65"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## 概要

親 Issue「Fable 5 監査: ~/.claude 設定の修正課題 17 件」（#21）の課題 1 に対応し、Opus 4.8 のツール結果捏造バグ調査の引き継ぎ資料（`HANDOVER-tool-fabrication-2026-06-19.md`）が残した未完了 TODO を決着させる。対象は `private_dot_claude/settings.json.tmpl`（`~/.claude/settings.json` のソース）のみ。

変更点は次の 3 つ。

- 1M コンテキストを無効化する（env に `CLAUDE_CODE_DISABLE_1M_CONTEXT: "1"` を追加）。Opus 4.8 + 1M + extended thinking + 長時間セッションがツール結果・偽ユーザーターンの捏造（Case B / anthropics/claude-code#69015 等）を誘発する既知の高リスク構成であり、コスト・安定性リスクが常用のメリットを上回るため。
- effort を medium で固定する（`"effortLevel": "medium"`）。1M 無効化とセットで Case B リスクを下げる HANDOVER の意図に従う。負荷の高いセッションでは `/effort high` で一時的に上げられる旨をコメントに残した。
- auto-compact 設定を 1M 無効化（200k コンテキスト運用）に整合させる。`CLAUDE_CODE_AUTO_COMPACT_WINDOW: "200000"` を復活し、`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` を 30→65 に戻す。PCT=30 は 1M 有効を前提にした値で、200k 運用のままだと約 60k で compact が発火し早すぎるため。

判断理由・再有効化条件・PCT と 1M の依存関係は、いずれも tmpl 内の Go template コメント `{{/* ... */}}`（レンダリング結果に出ない）で残した。

### 引き継ぎ資料 TODO との対応

本 PR で決着する TODO は 2 つ。「1M コンテキスト利用の要否を確認し無効化する」を無効化で決着させ、「モデルと effort を settings.json に固定する」を model=`claude-opus-4-8` 維持・effort=medium 固定で決着させた。CLI 最新化・`/bug` 報告・CLAUDE.md/rules 総量削減の TODO は本 PR のスコープ外。

### Issue 本文の前提との差異

Issue #22 は model 値を `claude-fable-5[1m]` と想定していたが、main の実態は既に `claude-opus-4-8`（`[1m]` サフィックスなし）だった。1M の制御は model 文字列ではなく env 変数 `CLAUDE_CODE_DISABLE_1M_CONTEXT` で行う構成のため、「`[1m]` 除去」ではなく「無効化フラグの追加」で対応した。~/.claude は Opus 用 config、Fable パイロットは別 config dir のため、model 名は Opus のまま変更していない。

## テスト計画

- `{{/* */}}` コメントを除去したレンダリング結果を `json.loads`（`python3 -m json.tool` 相当）で検証し、有効な JSON であることを確認済み（model=`claude-opus-4-8`、effortLevel=`medium`、env に 1M 無効化・WINDOW 200000・PCT 65 が反映）。
- `git diff --stat` で変更が `private_dot_claude/settings.json.tmpl` の 1 ファイルのみ・バイナリ/artifact 混入なしを確認済み。
- テンプレート構造の変数化・マシン分岐は本 PR のスコープ外（別 Issue #6 に委ねる）。

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
