### PR TITLE
chezmoi 未管理の agents/commands を取り込み、残課題を後始末手順として整理

### DIFF
--- a/private_dot_claude/agents/db-analyst.md
+++ b/private_dot_claude/agents/db-analyst.md
@@ -1,0 +1,110 @@
+---
+name: db-analyst
+description: READ-ONLY DB analyst agent. Investigates database schema, runs analytical queries, and produces structured reports. Use via Task tool with subagent_type "db-analyst".
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# DB Analyst Agent
+
+You are a READ-ONLY database analyst agent. You investigate database schemas, run analytical queries, and produce structured investigation reports.
+
+## Critical constraints
+
+- **STRICTLY READ-ONLY** — You may ONLY execute: `SELECT`, `SHOW`, `DESCRIBE`, `EXPLAIN`
+- **NEVER** execute write operations: INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, TRUNCATE, REPLACE, RENAME, GRANT, REVOKE
+- Before running ANY mysql command, verify the query is read-only. If unsure, do NOT execute.
+- Always use `MYSQL_PWD` environment variable for passwords — never `-p` flag
+- Always use `--default-character-set=utf8mb4`
+- Always apply `LIMIT` to SELECT queries (max 1000 rows for analysis, 100 for samples)
+
+## Setup
+
+1. Read `.claude/db-profiles.json` from the project root to get connection details
+2. Use the profile specified in the task prompt, or the `"default": true` profile
+3. If the password is `"FROM_SECRETS_MANAGER"`, report this to the caller — do not attempt to resolve secrets yourself
+4. Test the connection before proceeding:
+   ```bash
+   MYSQL_PWD='<password>' mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> -e "SELECT 1"
+   ```
+
+## Investigation workflow
+
+### Phase 1: Schema discovery
+
+```bash
+# List tables with row counts
+MYSQL_PWD='<password>' mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> -B -e \
+  "SELECT TABLE_NAME, TABLE_ROWS, DATA_LENGTH, INDEX_LENGTH FROM information_schema.TABLES WHERE TABLE_SCHEMA = '<database>' ORDER BY TABLE_NAME"
+
+# Describe relevant tables
+MYSQL_PWD='<password>' mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> -B -e "DESCRIBE <table>"
+
+# Check indexes
+MYSQL_PWD='<password>' mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> -B -e "SHOW INDEX FROM <table>"
+
+# Check foreign keys
+MYSQL_PWD='<password>' mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> -B -e \
+  "SELECT TABLE_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = '<database>' AND REFERENCED_TABLE_NAME IS NOT NULL"
+```
+
+### Phase 2: Targeted queries
+
+Based on the investigation task, run analytical queries:
+- Use `EXPLAIN` before expensive queries to check execution plans
+- Apply appropriate `LIMIT` (default 100 for samples, up to 1000 for aggregations)
+- Use aggregation functions (COUNT, SUM, AVG, MIN, MAX, GROUP BY) for data analysis
+- Join tables as needed for relational analysis
+
+### Phase 3: Analysis
+
+Analyze the results, identify patterns, anomalies, and insights relevant to the investigation task.
+
+## Output format
+
+Always produce a structured report in this format:
+
+```markdown
+# Investigation Report
+
+## Summary
+<1-3 sentence overview of findings>
+
+## Schema Context
+<Relevant tables, their relationships, and key columns>
+
+| Table | Rows (approx) | Key Columns | Notes |
+|-------|---------------|-------------|-------|
+| ... | ... | ... | ... |
+
+## Findings
+
+### Finding 1: <title>
+<Description with supporting data>
+
+| ... | ... |
+|-----|-----|
+
+### Finding 2: <title>
+...
+
+## Recommendations
+- <Actionable recommendation 1>
+- <Actionable recommendation 2>
+- ...
+```
+
+## Query execution helper
+
+For all mysql commands, use this pattern:
+
+```bash
+MYSQL_PWD='<password>' mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> --column-names -B -e "<query>"
+```
+
+- `--column-names -B` gives tab-separated output with headers (easy to read and parse)
+- Always capture stderr to detect errors: append `2>&1`
+- Check exit code and handle errors gracefully

--- a/private_dot_claude/commands/gws-calendar.md
+++ b/private_dot_claude/commands/gws-calendar.md
@@ -1,0 +1,38 @@
+Google Calendar を `gws` CLI で操作してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## ヘルパーコマンド
+
+```bash
+# 予定一覧
+command gws calendar +agenda                        # 今後の予定
+command gws calendar +agenda --today                # 今日
+command gws calendar +agenda --tomorrow             # 明日
+command gws calendar +agenda --week --format table  # 今週
+command gws calendar +agenda --days 3               # 3日間
+command gws calendar +agenda --calendar 'Work'      # 特定カレンダー
+
+# 予定作成
+command gws calendar +insert --summary 'Meeting' --start '2026-01-01T10:00:00+09:00' --end '2026-01-01T11:00:00+09:00'
+command gws calendar +insert --summary 'Review' --start ... --end ... --attendee alice@example.com --location 'Room A'
+```
+
+## API リソース
+
+```bash
+command gws calendar events list --params '{"calendarId": "primary", "timeMin": "2026-01-01T00:00:00Z", "maxResults": 10, "singleEvents": true, "orderBy": "startTime"}'
+command gws calendar events get --params '{"calendarId": "primary", "eventId": "EVENT_ID"}'
+command gws calendar events insert --params '{"calendarId": "primary"}' --json '{"summary": "...", "start": {"dateTime": "..."}, "end": {"dateTime": "..."}}'
+command gws calendar events quickAdd --params '{"calendarId": "primary", "text": "Meeting tomorrow 3pm"}'
+command gws calendar events delete --params '{"calendarId": "primary", "eventId": "EVENT_ID"}'
+command gws calendar calendarList list
+command gws calendar freebusy query --json '{"timeMin": "...", "timeMax": "...", "items": [{"id": "primary"}]}'
+```
+
+## セキュリティ
+
+- 予定の作成・変更・削除は**実行前に必ずユーザーに確認**
+- 時刻は RFC3339 形式 (例: `2026-01-01T10:00:00+09:00`)
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws-chat.md
+++ b/private_dot_claude/commands/gws-chat.md
@@ -1,0 +1,33 @@
+Google Chat を `gws` CLI で操作してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## ヘルパーコマンド
+
+```bash
+# メッセージ送信
+command gws chat +send --space spaces/AAAA --text 'Hello!'
+```
+
+## API リソース
+
+```bash
+# スペース
+command gws chat spaces list
+command gws chat spaces get --params '{"name": "spaces/SPACE_ID"}'
+command gws chat spaces create --json '{"displayName": "Team Chat", "spaceType": "SPACE"}'
+
+# メッセージ
+command gws chat spaces messages list --params '{"parent": "spaces/SPACE_ID"}'
+command gws chat spaces messages get --params '{"name": "spaces/SPACE_ID/messages/MSG_ID"}'
+command gws chat spaces messages create --params '{"parent": "spaces/SPACE_ID"}' --json '{"text": "Hello!"}'
+
+# メンバー
+command gws chat spaces members list --params '{"parent": "spaces/SPACE_ID"}'
+```
+
+## セキュリティ
+
+- メッセージ送信は**実行前に必ずユーザーに確認**
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws-docs.md
+++ b/private_dot_claude/commands/gws-docs.md
@@ -1,0 +1,29 @@
+Google Docs を `gws` CLI で操作してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## ヘルパーコマンド
+
+```bash
+# テキスト追記
+command gws docs +write --document <ID> --text 'Hello, world!'
+```
+
+## API リソース
+
+```bash
+# ドキュメント取得
+command gws docs documents get --params '{"documentId": "DOC_ID"}'
+
+# ドキュメント作成
+command gws docs documents create --json '{"title": "New Document"}'
+
+# バッチ更新（リッチフォーマット）
+command gws docs documents batchUpdate --params '{"documentId": "DOC_ID"}' --json '{"requests": [{"insertText": {"location": {"index": 1}, "text": "Hello"}}]}'
+```
+
+## セキュリティ
+
+- 書き込み操作 (`+write`, `batchUpdate`, `create`) は**実行前に必ずユーザーに確認**
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws-drive.md
+++ b/private_dot_claude/commands/gws-drive.md
@@ -1,0 +1,43 @@
+Google Drive を `gws` CLI で操作してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## ヘルパーコマンド
+
+```bash
+# ファイルアップロード
+command gws drive +upload ./file.pdf
+command gws drive +upload ./file.pdf --parent FOLDER_ID
+command gws drive +upload ./data.csv --name 'Sales Data.csv'
+```
+
+## API リソース
+
+```bash
+# ファイル操作
+command gws drive files list --params '{"pageSize": 10}'
+command gws drive files list --params '{"q": "mimeType=\"application/vnd.google-apps.folder\"", "pageSize": 20}'
+command gws drive files get --params '{"fileId": "FILE_ID"}'
+command gws drive files create --json '{"name": "New Folder", "mimeType": "application/vnd.google-apps.folder"}'
+command gws drive files copy --params '{"fileId": "FILE_ID"}' --json '{"name": "Copy of file"}'
+command gws drive files update --params '{"fileId": "FILE_ID"}' --json '{"name": "Renamed"}'
+command gws drive files delete --params '{"fileId": "FILE_ID"}'
+command gws drive files export --params '{"fileId": "FILE_ID", "mimeType": "application/pdf"}' -o output.pdf
+
+# 権限
+command gws drive permissions list --params '{"fileId": "FILE_ID"}'
+command gws drive permissions create --params '{"fileId": "FILE_ID"}' --json '{"role": "reader", "type": "user", "emailAddress": "user@example.com"}'
+
+# 共有ドライブ
+command gws drive drives list
+command gws drive drives get --params '{"driveId": "DRIVE_ID"}'
+
+# ダウンロード
+command gws drive files get --params '{"fileId": "FILE_ID", "alt": "media"}' -o downloaded_file
+```
+
+## セキュリティ
+
+- ファイルの作成・アップロード・削除・権限変更は**実行前に必ずユーザーに確認**
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws-gmail.md
+++ b/private_dot_claude/commands/gws-gmail.md
@@ -1,0 +1,42 @@
+Gmail を `gws` CLI で操作してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## ヘルパーコマンド
+
+```bash
+# メール送信
+command gws gmail +send --to <EMAIL> --subject <SUBJECT> --body <TEXT>
+
+# 未読メール一覧（トリアージ）
+command gws gmail +triage
+command gws gmail +triage --max 5 --query 'from:boss'
+command gws gmail +triage --labels --format table
+```
+
+## API リソース
+
+```bash
+command gws gmail users getProfile --params '{"userId": "me"}'
+command gws gmail users messages list --params '{"userId": "me", "q": "is:unread"}'
+command gws gmail users messages get --params '{"userId": "me", "id": "MSG_ID"}'
+command gws gmail users messages send --params '{"userId": "me"}' --json '{"raw": "BASE64_ENCODED"}'
+command gws gmail users messages modify --params '{"userId": "me", "id": "MSG_ID"}' --json '{"addLabelIds": ["LABEL_ID"]}'
+command gws gmail users labels list --params '{"userId": "me"}'
+command gws gmail users drafts list --params '{"userId": "me"}'
+command gws gmail users threads list --params '{"userId": "me"}'
+```
+
+## スキーマ確認
+
+```bash
+command gws schema gmail.users.messages.list
+command gws gmail --help
+```
+
+## セキュリティ
+
+- メール送信 (`+send`, `messages.send`) は**実行前に必ずユーザーに確認**
+- `modify`, `delete` も確認必須
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws-sheets.md
+++ b/private_dot_claude/commands/gws-sheets.md
@@ -1,0 +1,37 @@
+Google Sheets を `gws` CLI で操作してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## ヘルパーコマンド
+
+```bash
+# スプレッドシート読み取り
+command gws sheets +read --spreadsheet <ID> --range 'Sheet1!A1:D10'
+command gws sheets +read --spreadsheet <ID> --range Sheet1
+
+# 行追加
+command gws sheets +append --spreadsheet <ID> --values 'Alice,100,true'
+command gws sheets +append --spreadsheet <ID> --json-values '[["a","b"],["c","d"]]'
+```
+
+## API リソース
+
+```bash
+# スプレッドシート操作
+command gws sheets spreadsheets get --params '{"spreadsheetId": "ID"}'
+command gws sheets spreadsheets create --json '{"properties": {"title": "New Sheet"}}'
+
+# 値の読み書き
+command gws sheets spreadsheets values get --params '{"spreadsheetId": "ID", "range": "Sheet1!A1:D10"}'
+command gws sheets spreadsheets values update --params '{"spreadsheetId": "ID", "range": "Sheet1!A1", "valueInputOption": "USER_ENTERED"}' --json '{"values": [["a","b"],["c","d"]]}'
+command gws sheets spreadsheets values append --params '{"spreadsheetId": "ID", "range": "Sheet1", "valueInputOption": "USER_ENTERED"}' --json '{"values": [["new","row"]]}'
+
+# バッチ操作
+command gws sheets spreadsheets batchUpdate --params '{"spreadsheetId": "ID"}' --json '{"requests": [...]}'
+```
+
+## セキュリティ
+
+- 書き込み操作 (`+append`, `values update`, `batchUpdate`) は**実行前に必ずユーザーに確認**
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws-tasks.md
+++ b/private_dot_claude/commands/gws-tasks.md
@@ -1,0 +1,27 @@
+Google Tasks を `gws` CLI で操作してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## API リソース
+
+```bash
+# タスクリスト
+command gws tasks tasklists list
+command gws tasks tasklists get --params '{"tasklist": "TASKLIST_ID"}'
+command gws tasks tasklists insert --json '{"title": "New List"}'
+command gws tasks tasklists delete --params '{"tasklist": "TASKLIST_ID"}'
+
+# タスク
+command gws tasks tasks list --params '{"tasklist": "TASKLIST_ID"}'
+command gws tasks tasks get --params '{"tasklist": "TASKLIST_ID", "task": "TASK_ID"}'
+command gws tasks tasks insert --params '{"tasklist": "TASKLIST_ID"}' --json '{"title": "Buy milk", "due": "2026-01-15T00:00:00Z"}'
+command gws tasks tasks patch --params '{"tasklist": "TASKLIST_ID", "task": "TASK_ID"}' --json '{"status": "completed"}'
+command gws tasks tasks delete --params '{"tasklist": "TASKLIST_ID", "task": "TASK_ID"}'
+command gws tasks tasks move --params '{"tasklist": "TASKLIST_ID", "task": "TASK_ID", "parent": "PARENT_TASK_ID"}'
+```
+
+## セキュリティ
+
+- タスクの作成・変更・削除は**実行前に必ずユーザーに確認**
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws-workflow.md
+++ b/private_dot_claude/commands/gws-workflow.md
@@ -1,0 +1,40 @@
+Google Workspace のクロスサービスワークフローを `gws` CLI で実行してください。`command gws` でバイナリを呼び出すこと（エイリアス回避）。
+
+## ワークフローコマンド
+
+```bash
+# スタンドアップレポート: 今日のミーティング + 未完了タスクのサマリー
+command gws workflow +standup-report
+
+# ミーティング準備: 次のミーティングのアジェンダ、参加者、関連ドキュメント
+command gws workflow +meeting-prep
+
+# 週間ダイジェスト: 今週のミーティング + 未読メール数
+command gws workflow +weekly-digest
+
+# メール→タスク変換: Gmail メッセージを Google Tasks に変換
+command gws workflow +email-to-task
+
+# ファイルアナウンス: Drive ファイルを Chat スペースで共有
+command gws workflow +file-announce
+```
+
+## 組み合わせ例
+
+```bash
+# 朝のルーティン
+command gws workflow +standup-report
+command gws gmail +triage --max 10 --format table
+
+# ミーティング前
+command gws workflow +meeting-prep
+command gws calendar +agenda --today --format table
+
+# 週初め
+command gws workflow +weekly-digest
+command gws calendar +agenda --week --format table
+```
+
+## ユーザーのリクエスト
+
+$ARGUMENTS

--- a/private_dot_claude/commands/gws.md
+++ b/private_dot_claude/commands/gws.md
@@ -1,0 +1,115 @@
+Google Workspace CLI (`gws`) を使って、ユーザーのリクエストを実行してください。
+
+## 重要: バイナリパス
+
+`gws` は zsh で git エイリアスと競合する可能性があります。
+Bash ツールでは以下のようにフルパスで実行してください:
+
+```bash
+command gws <args>
+```
+
+## 認証
+
+```bash
+command gws auth status    # 認証状態確認
+command gws auth login     # OAuth ログイン（初回 or 期限切れ時）
+command gws auth login -s drive,gmail,calendar,sheets,docs,tasks,chat  # スコープ指定
+```
+
+## CLI 構文
+
+```bash
+command gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### グローバルフラグ
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key":"val"}'` | URL/クエリパラメータ |
+| `--json '{"key":"val"}'` | リクエストボディ |
+| `--format <json\|table\|yaml\|csv>` | 出力形式 (デフォルト: json) |
+| `--dry-run` | API呼び出しなしで検証 |
+| `--upload <PATH>` | ファイルアップロード |
+| `-o, --output <PATH>` | バイナリレスポンス保存先 |
+| `--page-all` | 自動ページネーション (NDJSON) |
+| `--page-limit <N>` | 最大ページ数 (デフォルト: 10) |
+
+## 対応サービスと主要ヘルパーコマンド
+
+### Gmail
+```bash
+command gws gmail +send --to <EMAIL> --subject <SUBJECT> --body <TEXT>
+command gws gmail +triage                          # 未読メール一覧
+command gws gmail +triage --max 5 --query 'from:boss'
+command gws gmail users messages list --params '{"userId": "me", "q": "is:unread"}'
+```
+
+### Calendar
+```bash
+command gws calendar +agenda                       # 今後の予定一覧
+command gws calendar +agenda --today               # 今日の予定
+command gws calendar +agenda --week --format table  # 今週の予定
+command gws calendar +insert --summary 'Meeting' --start '2026-01-01T10:00:00+09:00' --end '2026-01-01T11:00:00+09:00'
+```
+
+### Drive
+```bash
+command gws drive files list --params '{"pageSize": 10}'
+command gws drive +upload ./file.pdf
+command gws drive +upload ./file.pdf --parent FOLDER_ID
+command gws drive files get --params '{"fileId": "ID"}'
+```
+
+### Sheets
+```bash
+command gws sheets +read --spreadsheet <ID> --range 'Sheet1!A1:D10'
+command gws sheets +append --spreadsheet <ID> --values 'Alice,100,true'
+command gws sheets +append --spreadsheet <ID> --json-values '[["a","b"],["c","d"]]'
+```
+
+### Docs
+```bash
+command gws docs documents get --params '{"documentId": "ID"}'
+command gws docs documents create --json '{"title": "New Doc"}'
+command gws docs +write --document <ID> --text 'Hello, world!'
+```
+
+### Tasks
+```bash
+command gws tasks tasklists list
+command gws tasks tasks list --params '{"tasklist": "TASKLIST_ID"}'
+command gws tasks tasks insert --params '{"tasklist": "TASKLIST_ID"}' --json '{"title": "New task"}'
+```
+
+### Chat
+```bash
+command gws chat spaces list
+command gws chat +send --space spaces/AAAA --text 'Hello!'
+```
+
+### Workflow (クロスサービス)
+```bash
+command gws workflow +standup-report    # 今日のミーティング + 未完了タスク
+command gws workflow +meeting-prep      # 次のミーティングの準備情報
+command gws workflow +weekly-digest     # 週間サマリー
+command gws workflow +email-to-task     # メールをタスクに変換
+```
+
+## コマンド探索
+
+```bash
+command gws <service> --help                        # リソース一覧
+command gws schema <service>.<resource>.<method>    # メソッドの詳細スキーマ
+```
+
+## セキュリティルール
+
+- **書き込み/削除コマンドは実行前に必ずユーザーに確認**
+- トークンやAPIキーを出力に含めない
+- 破壊的操作には `--dry-run` を先に実行して確認
+
+## ユーザーのリクエスト
+
+$ARGUMENTS


### PR DESCRIPTION
## 概要

`~/.claude` 配下（Claude Code の設定ディレクトリ）に、chezmoi の管理から漏れていたファイルがあった。マシンを再構築すると、これらのファイルは失われる。この課題を解決するため、以下 2 グループのファイルを chezmoi のソースディレクトリへ手動でコピーした。

取り込んだファイル:

- DB 調査用の read-only サブエージェント定義（`private_dot_claude/agents/db-analyst.md`）
- Google Workspace 操作用のスラッシュコマンド定義 9 ファイル（`private_dot_claude/commands/gws.md`、`gws-calendar.md`、`gws-chat.md`、`gws-docs.md`、`gws-drive.md`、`gws-gmail.md`、`gws-sheets.md`、`gws-tasks.md`、`gws-workflow.md`）

Issue 本文では gws 系ファイルを 10 ファイルと記載していたが、実際に `~/.claude/commands/` を確認したところ 9 ファイルだった。件数の記載が実態と異なっていたため、実際に存在する 9 ファイルを取り込んでいる。

コピー前に、各ファイルの中身を読んで秘密情報（API キー・トークン・パスワード・認証情報）が含まれていないかを確認した。

- `db-analyst.md` は DB 接続コマンドのテンプレートであり、パスワードは `<password>` のようなプレースホルダーのみで実際の認証情報は含まれていない
- `gws*.md` の 9 ファイルは Google Workspace CLI の使い方を説明するドキュメントであり、含まれる ID・メールアドレス（`user@example.com` 等）はすべてプレースホルダー

秘密情報は見つからなかったため、そのまま取り込んだ。コピー後、`diff` コマンドでコピー元とコピー先の内容が完全に一致することを確認済み。

## 後始末手順（post-apply cleanup）

以下 3 件は、今回のリポジトリへの取り込み対象から外した。理由は、他の Issue（別課題）の判断待ちであるか、chezmoi 管理下に置くべきではない一時的な成果物のため。**このリポジトリの変更では `~/.claude` 配下のファイル移動・削除は行っていない**。以下の手順は、根拠となる各 PR がマージされたあとに手動で実行すること。

1. **ツール呼び出し衛生ガイド（`~/.claude/docs/tool-call-hygiene-guide.md`）**: 廃止方針は、別 Issue（参照整合性バッチを扱う Sub-issue、[#28](https://github.com/phantom-suzuki/dotfiles/issues/28)）の PR（#33、未マージ）で決定した方針に基づく。PR #33 のマージ後、ルールの正本（`~/.claude/rules/tool-call-hygiene.md`）に内容が集約されるため、`~/.claude/docs/tool-call-hygiene-guide.md` を手動で削除する。
2. **ツール結果捏造バグの引き継ぎ資料（`~/.claude/HANDOVER-tool-fabrication-2026-06-19.md`）**: 未完了だった TODO の決着は、別 Issue（設定再設計を扱う Sub-issue、[#22](https://github.com/phantom-suzuki/dotfiles/issues/22)）の PR（#32、未マージ）で決定した方針に基づく。PR #32 のマージ後、`~/.claude/HANDOVER-tool-fabrication-2026-06-19.md` を `~/.claude/archive/` へ移動する（削除はしない）。
3. **PR レビューワークスペース（`~/.claude/skills/pr-reviewer-workspace/`）**: pr-reviewer スキルのベンチマークを実行した結果ファイル一式（268KB・23 ファイル）で、スキル本体ではない。スキル定義を置く `~/.claude/skills/` に置くべきではないため、`~/.claude/archive/` 等の別ディレクトリへ手動で退避する。

**保留事項**: Issue #29 の受け入れ条件は 5 項目あり、本 PR が満たすのは「agents/commands の取り込み」1 項目のみ。残る後始末 3 件（衛生ガイド削除 / HANDOVER アーカイブ / pr-reviewer-workspace 退避）は上記の手動作業に先送りしているため、Issue #29 はこの 3 件が完了するまでオープンのまま残す。

## テスト計画

- [x] `db-analyst.md` と `gws*.md`（9 ファイル）の中身を読んで秘密情報が含まれないことを確認した
- [x] コピー元（`~/.claude/` 配下）とコピー先（`private_dot_claude/` 配下）の内容が `diff` で完全一致することを確認した
- [x] `.chezmoiignore` に今回のパス（`private_dot_claude/agents/`、`private_dot_claude/commands/`）を除外する記述がないことを確認した
- [x] `git diff --stat` で新規 10 ファイルのみが差分に含まれ、バイナリファイルや意図しない成果物が混入していないことを確認した
- [ ] マージ後、`chezmoi apply` を実行して `~/.claude/agents/db-analyst.md` と `~/.claude/commands/gws*.md` が chezmoi 管理下で正しく展開されることを確認する（担当者が手動実施）
- [ ] マージ後、上記「後始末手順」の 3 件を手動で実行する（担当者が手動実施）

Refs #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
