### PR TITLE
settings.json.tmpl を chezmoi data 変数で汎用化（#22 決定値を default 維持）

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,3 +1,13 @@
 [data]
     name = "{{ promptStringOnce . "name" "Git user name" }}"
     email = "{{ promptStringOnce . "email" "Git email" }}"
+
+# Claude Code settings.json.tmpl のマシン固有・個人固有の値を上書きする。
+# 未定義のままなら #22 で決めた default 値がレンダリングされる（後方互換）。
+# マシンごとに変えたいときだけ [data.claude] のコメントを外して値を設定する。
+# [data.claude]
+#     model = "claude-opus-4-8"      # モデル名（default: claude-opus-4-8）
+#     effortLevel = "medium"          # reasoning effort（default: medium）
+#     disable1m = "1"                 # 1M コンテキスト無効化（"1"=無効 / "0"=有効, default: "1"）
+#     autoCompactWindow = "200000"    # auto-compact のコンテキスト窓（default: 200000, 1M 無効前提）
+#     autoCompactPct = "65"           # auto-compact 発火閾値 %（default: 65, 1M 無効前提）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Go template 構文（`{{ .variable }}`）を使用するファイル:
 | `dot_gitconfig.tmpl` | `~/.gitconfig` | `{{ .name }}`, `{{ .email }}` |
 | `dot_zshrc.tmpl` | `~/.zshrc` | なし（将来のマシン分岐用に `.tmpl` 維持） |
 | `.chezmoi.toml.tmpl` | `~/.config/chezmoi/chezmoi.toml` | `promptStringOnce` で初回入力 |
+| `private_dot_claude/settings.json.tmpl` | `~/.claude/settings.json` | `data.claude.*`（省略時は default 値。下表参照） |
 | `run_once_install-packages.sh.tmpl` | (実行のみ) | `{{ .chezmoi.sourceDir }}` |
 
 変数は `~/.config/chezmoi/chezmoi.toml` で定義:
@@ -31,6 +32,31 @@ Go template 構文（`{{ .variable }}`）を使用するファイル:
     name = "phantom-suzuki"
     email = "h.suzuki@sorenalab.com"
 ```
+
+### Claude Code settings の上書き変数（`data.claude.*`）
+
+`private_dot_claude/settings.json.tmpl`（`~/.claude/settings.json` を生成する chezmoi テンプレート）のマシン固有・個人固有になり得る値は、`data.claude.*` で上書きできる。`dig` 関数で「未定義なら default」にフォールバックするため、`[data.claude]` を書かなくても現状と同一の JSON が生成される（後方互換）。default 値は settings.json のモデル・1M コンテキスト設定を再設計した Issue #22 の決定値。
+
+| 変数 | 意味 | default |
+|------|------|---------|
+| `data.claude.model` | モデル名 | `claude-opus-4-8` |
+| `data.claude.effortLevel` | reasoning effort | `medium` |
+| `data.claude.disable1m` | 1M コンテキスト無効化（`"1"`=無効 / `"0"`=有効） | `"1"` |
+| `data.claude.autoCompactWindow` | auto-compact のコンテキスト窓 | `200000` |
+| `data.claude.autoCompactPct` | auto-compact 発火閾値 % | `65` |
+
+マシンごとに変えたいときは `~/.config/chezmoi/chezmoi.toml` の `[data.claude]` に値を書く（例は `.chezmoi.toml.tmpl` のコメント参照）:
+
+```toml
+[data.claude]
+    model = "claude-opus-4-8"
+    effortLevel = "medium"
+    disable1m = "1"
+    autoCompactWindow = "200000"
+    autoCompactPct = "65"
+```
+
+> **注意（1M と auto-compact の依存）**: `disable1m` を `"0"`（1M 有効）に戻す場合、`autoCompactWindow` / `autoCompactPct` も 1M 前提の値に見直すこと。理由は `settings.json.tmpl` 内の `{{/* */}}` コメントに記載。
 
 ## 外部リポジトリ
 

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -1,12 +1,14 @@
 {
-  "model": "claude-opus-4-8",
+  {{/* 上書き: data.claude.model で変更可。未定義なら下の default（#22 の決定値）。 */}}
+  "model": "{{ dig "claude" "model" "claude-opus-4-8" . }}",
   {{/*
     effort は medium で固定する。理由: Opus 4.8 + 1M context + high effort が
     Case B（tool_use ブロック欠落）の既知高リスク構成であり、下の 1M 無効化と
     セットで effort も落とすのが HANDOVER-tool-fabrication-2026-06-19.md の意図。
     個別セッションで負荷の高い作業をするときは `/effort high` で一時的に上げられる。
   */}}
-  "effortLevel": "medium",
+  {{/* 上書き: data.claude.effortLevel で変更可。未定義なら default（#22 の決定値）。 */}}
+  "effortLevel": "{{ dig "claude" "effortLevel" "medium" . }}",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
@@ -19,7 +21,8 @@
       再有効化してよい条件: Fable 5 等で長大コンテキストが実際に必要になり、その構成で
       安定性を実測確認できた場合のみ。
     */}}
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
+    {{/* 上書き: data.claude.disable1m（"1"=無効/"0"=有効）で変更可。未定義なら default（#22 の決定値=無効）。 */}}
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "{{ dig "claude" "disable1m" "1" . }}",
     {{/*
       以下 2 つの auto-compact 設定は 1M 無効化（= 200k コンテキスト運用）に整合させた値。
       WINDOW=200000・PCT=65 で概ね 130k 到達時に compact が発火する。
@@ -27,8 +30,9 @@
       compact が発火し早すぎる。1M 無効化と PCT はセットの依存関係にあるため、1M を戻す
       場合はこの 2 値も 1M 前提（PCT=30・WINDOW 撤去）に合わせて見直すこと。
     */}}
-    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "65"
+    {{/* 上書き: data.claude.autoCompactWindow / data.claude.autoCompactPct で変更可。未定義なら default（#22 の決定値）。1M を戻す場合は上のコメント参照。 */}}
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "{{ dig "claude" "autoCompactWindow" "200000" . }}",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "{{ dig "claude" "autoCompactPct" "65" . }}"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
> **積み上げ PR（stacked PR）です**: この PR は PR #32（Issue #22 対応、settings.json のモデル・1M コンテキスト設定の再設計）のブランチ `feature/22-settings-model-redesign` に積み上げています。base は `main` ではなく `feature/22-settings-model-redesign` です。#32 のマージ後に main へ向け直してください。

## 概要

Claude Code の設定テンプレート（`private_dot_claude/settings.json.tmpl`、`~/.claude/settings.json` を生成する chezmoi テンプレート）を汎用化しました。マシン固有・個人固有になり得るスカラー値を、chezmoi の `data.claude.*` 変数で上書きできる構造にしています。

`dig` 関数で「data 未定義なら default」にフォールバックするため、`[data.claude]` を書かなければ従来と同一の JSON が生成されます（後方互換）。default 値は Issue #22 で決めた値をそのまま維持しています。

### 変数化した項目

| 変数 | 意味 | default（#22 の決定値） |
|------|------|------|
| `data.claude.model` | モデル名 | `claude-opus-4-8` |
| `data.claude.effortLevel` | reasoning effort | `medium` |
| `data.claude.disable1m` | 1M コンテキスト無効化（`"1"`=無効 / `"0"`=有効） | `"1"` |
| `data.claude.autoCompactWindow` | auto-compact のコンテキスト窓 | `200000` |
| `data.claude.autoCompactPct` | auto-compact 発火閾値 % | `65` |

### 変更ファイル

- `private_dot_claude/settings.json.tmpl` — 上記 5 値を `dig` によるフォールバック付きで変数化。#22 の `{{/* */}}` 判断理由コメントは保持し、変数化した箇所に「上書き方法」のコメントを 1 行ずつ追加。
- `.chezmoi.toml.tmpl` — `[data.claude]` の上書き例をコメントで追加。既存の `name` / `email`（`promptStringOnce`）の挙動は変更なし。
- `CLAUDE.md`（chezmoi ソース用）— テンプレートファイル一覧表に settings.json.tmpl を追加し、`data.claude.*` の変数表と上書き手順を追記。

## テスト計画

`chezmoi execute-template`（読み取り専用のレンダリングコマンド）で ①data 未定義 ②data 定義済み の両方を検証しました。`chezmoi apply` / `diff` / `add` は未実行です。

### ① 後方互換: data 未定義時のレンダリングが変更前と同一

base ブランチ（変更前）のテンプレートと、この PR のテンプレートを、それぞれ `chezmoi execute-template` でレンダリングして比較しました。

```
$ diff <(jq -S . render_base.json) <(jq -S . render_default.json)
（差分なし = JSON-EQUAL）
```

バイト差分は `{{/* */}}` コメント行由来の空行のみで、これはテンプレートの既存慣習（#22 のコメントも同様に空行を生む）と一致します。JSON としての意味は完全に同一です。

### ② data 定義時に上書きが反映される

一時 config（`--config` で注入、リポジトリ設定は不変更）に override 値を入れてレンダリングし、default との差分を確認しました。

```
$ diff <(jq -S '{model,effortLevel,env}' render_default.json) \
       <(jq -S '{model,effortLevel,env}' render_override.json)
<   "effortLevel": "medium"          --->   "effortLevel": "high"
<   "model": "claude-opus-4-8"       --->   "model": "claude-sonnet-4-6"
<   "d(disable1m)": "1"              --->   "d(disable1m)": "0"
<   "w(autoCompactWindow)": "200000" --->   "w(autoCompactWindow)": "1000000"
<   "p(autoCompactPct)": "65"        --->   "p(autoCompactPct)": "30"
```

両ケースとも `jq` で有効な JSON であること、および該当キーが期待値になることを確認済みです。

## 保留事項（Issue #6 の残 AC）

Issue #6 の受け入れ条件のうち、以下は**本 PR では未対応**です。

- `mcpServers` / `hooks` のコマンドパス / `permissions` / `env` の **マシン・OS 分岐**（Go template 条件分岐）

理由: 複数マシンの実差異データがまだ無い段階で OS 分岐の器を作ると過剰設計になりやすく、後方互換の検証面積も広がるためです。複数マシンの実差異が確定してから、別 Issue で設計・実装します。

このため本 PR には `Closes #6` を付けず、`Refs #6` としています。

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
