### PR TITLE
settings.json.tmpl を chezmoi data 変数で汎用化（default は現行 main 値を維持）

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,3 +1,13 @@
 [data]
     name = "{{ promptStringOnce . "name" "Git user name" }}"
     email = "{{ promptStringOnce . "email" "Git email" }}"
+
+# Claude Code settings.json.tmpl のマシン固有・個人固有の値を上書きする。
+# 未定義のままなら現行 main の設定と同一の JSON がレンダリングされる（後方互換）。
+# マシンごとに変えたいときだけ [data.claude] のコメントを外して値を設定する。
+# [data.claude]
+#     model = "claude-opus-4-8"      # モデル名（default: claude-opus-4-8）
+#     effortLevel = "medium"          # reasoning effort（default: 未設定 = キー非出力、ハーネス既定）
+#     disable1m = "1"                 # 1M コンテキスト無効化 "1"=無効/"0"=有効（default: 未設定 = 1M 有効）
+#     autoCompactWindow = "200000"    # auto-compact のコンテキスト窓（default: 未設定。1M 無効の 200k 運用時に設定）
+#     autoCompactPct = "65"           # auto-compact 発火閾値 %（default: 30 = 1M 前提。200k 運用時は 65 目安）

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -5,6 +5,8 @@
 # Claude Code settings.json.tmpl のマシン固有・個人固有の値を上書きする。
 # 未定義のままなら現行 main の設定と同一の JSON がレンダリングされる（後方互換）。
 # マシンごとに変えたいときだけ [data.claude] のコメントを外して値を設定する。
+# 値は必ず引用符付きの文字列で書くこと（整数・boolean で書くと、falsy 判定や
+# 出力値がドキュメントの想定と変わる。例: disable1m = 0 はキー自体が出力されない）。
 # [data.claude]
 #     model = "claude-opus-4-8"      # モデル名（default: claude-opus-4-8）
 #     effortLevel = "medium"          # reasoning effort（default: 未設定 = キー非出力、ハーネス既定）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Go template 構文（`{{ .variable }}`）を使用するファイル:
 | `dot_gitconfig.tmpl` | `~/.gitconfig` | `{{ .name }}`, `{{ .email }}` |
 | `dot_zshrc.tmpl` | `~/.zshrc` | なし（将来のマシン分岐用に `.tmpl` 維持） |
 | `.chezmoi.toml.tmpl` | `~/.config/chezmoi/chezmoi.toml` | `promptStringOnce` で初回入力 |
+| `private_dot_claude/settings.json.tmpl` | `~/.claude/settings.json` | `data.claude.*`（省略時は default 値。下表参照） |
 | `run_once_install-packages.sh.tmpl` | (実行のみ) | `{{ .chezmoi.sourceDir }}` |
 
 変数は `~/.config/chezmoi/chezmoi.toml` で定義:
@@ -31,6 +32,30 @@ Go template 構文（`{{ .variable }}`）を使用するファイル:
     name = "phantom-suzuki"
     email = "h.suzuki@sorenalab.com"
 ```
+
+### Claude Code settings の上書き変数（`data.claude.*`）
+
+`private_dot_claude/settings.json.tmpl`（`~/.claude/settings.json` を生成する chezmoi テンプレート）のマシン固有・個人固有になり得る値は、`data.claude.*` で上書きできる。`[data.claude]` を書かなければ**現行 main の設定と同一の JSON** が生成される（後方互換）。任意キー（effortLevel / disable1m / autoCompactWindow）は未定義ならキー自体を出力しない。なお 1M 無効化・effort=medium 固定を default にする案（PR #32）は不採用のため、default には採用していない（判断記録は Issue #22）。
+
+| 変数 | 意味 | default |
+|------|------|---------|
+| `data.claude.model` | モデル名 | `claude-opus-4-8` |
+| `data.claude.effortLevel` | reasoning effort | 未設定（キー非出力 = ハーネス既定） |
+| `data.claude.disable1m` | 1M コンテキスト無効化（`"1"`=無効 / `"0"`=有効） | 未設定（キー非出力 = 1M 有効） |
+| `data.claude.autoCompactWindow` | auto-compact のコンテキスト窓 | 未設定（キー非出力） |
+| `data.claude.autoCompactPct` | auto-compact 発火閾値 % | `30`（1M 前提の値） |
+
+マシンごとに変えたいときは `~/.config/chezmoi/chezmoi.toml` の `[data.claude]` に値を書く（例は `.chezmoi.toml.tmpl` のコメント参照）:
+
+```toml
+[data.claude]
+    effortLevel = "medium"
+    disable1m = "1"
+    autoCompactWindow = "200000"
+    autoCompactPct = "65"
+```
+
+> **注意（1M と auto-compact の依存）**: `disable1m = "1"`（1M 無効 = 200k 運用）にする場合、`autoCompactWindow` / `autoCompactPct` も 200k 前提の値（例: 200000 / 65）へセットで合わせること。default の `autoCompactPct = 30` は 1M 有効前提の値。詳細は `settings.json.tmpl` 内の `{{/* */}}` コメントに記載。
 
 ## 外部リポジトリ
 

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -1,9 +1,32 @@
 {
-  "model": "claude-opus-4-8",
+  {{- /* 上書き: data.claude.model で変更可。未定義なら現行 default。 */}}
+  "model": "{{ dig "claude" "model" "claude-opus-4-8" . }}",
+  {{- /*
+    effortLevel は data.claude.effortLevel を定義したマシンでのみ出力する。
+    未定義ならキー自体を出力しない（= ハーネス既定に従う。現行 main と同一出力）。
+  */}}
+  {{- if dig "claude" "effortLevel" "" . }}
+  "effortLevel": "{{ dig "claude" "effortLevel" "" . }}",
+  {{- end }}
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
+    {{- /*
+      1M コンテキストの無効化（disable1m: "1"=無効 / "0"=明示的に有効）と
+      auto-compact 窓（autoCompactWindow）は、data.claude.* を定義したマシンでのみ出力する。
+      未定義ならキー自体を出力しない（= 1M 有効・窓はハーネス既定。現行 main と同一出力）。
+      1M 無効化（200k 運用）にするマシンでは、autoCompactPct も 200k 前提の値
+      （例: WINDOW=200000・PCT=65 で概ね 130k 到達時に compact 発火）へ合わせること。
+      default の PCT=30 は 1M 有効（大コンテキスト）前提の値。
+    */}}
+    {{- if dig "claude" "disable1m" "" . }}
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "{{ dig "claude" "disable1m" "" . }}",
+    {{- end }}
+    {{- if dig "claude" "autoCompactWindow" "" . }}
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "{{ dig "claude" "autoCompactWindow" "" . }}",
+    {{- end }}
+    {{- /* 上書き: data.claude.autoCompactPct で変更可。未定義なら現行 default（30 = 1M 前提）。 */}}
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "{{ dig "claude" "autoCompactPct" "30" . }}"
   },
   "permissions": {
     "allow": [

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -1,12 +1,14 @@
 {
-  {{- /* 上書き: data.claude.model で変更可。未定義なら現行 default。 */}}
-  "model": "{{ dig "claude" "model" "claude-opus-4-8" . }}",
+  {{- /* 上書き: data.claude.model で変更可。未定義なら現行 default。
+         値は toString | toJson で「文字列化 + JSON エスケープ」してから埋め込む
+         （quote や制御文字を含む値でも出力 JSON が壊れないようにするため）。 */}}
+  "model": {{ dig "claude" "model" "claude-opus-4-8" . | toString | toJson }},
   {{- /*
     effortLevel は data.claude.effortLevel を定義したマシンでのみ出力する。
     未定義ならキー自体を出力しない（= ハーネス既定に従う。現行 main と同一出力）。
   */}}
   {{- if dig "claude" "effortLevel" "" . }}
-  "effortLevel": "{{ dig "claude" "effortLevel" "" . }}",
+  "effortLevel": {{ dig "claude" "effortLevel" "" . | toString | toJson }},
   {{- end }}
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
@@ -20,13 +22,13 @@
       default の PCT=30 は 1M 有効（大コンテキスト）前提の値。
     */}}
     {{- if dig "claude" "disable1m" "" . }}
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "{{ dig "claude" "disable1m" "" . }}",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": {{ dig "claude" "disable1m" "" . | toString | toJson }},
     {{- end }}
     {{- if dig "claude" "autoCompactWindow" "" . }}
-    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "{{ dig "claude" "autoCompactWindow" "" . }}",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": {{ dig "claude" "autoCompactWindow" "" . | toString | toJson }},
     {{- end }}
     {{- /* 上書き: data.claude.autoCompactPct で変更可。未定義なら現行 default（30 = 1M 前提）。 */}}
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "{{ dig "claude" "autoCompactPct" "30" . }}"
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": {{ dig "claude" "autoCompactPct" "30" . | toString | toJson }}
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
> 旧 PR #38 の作り直し。旧 PR は不採用クローズした PR #32（1M 無効化）のブランチの上に積まれていたため、本命コミットだけを main へ cherry-pick して作成した。

## 概要

Claude Code の設定ファイルを生成するテンプレート（`private_dot_claude/settings.json.tmpl`）のマシン固有・個人固有になり得る値を、chezmoi の `data.claude.*` 変数で上書きできるようにする（Issue #6）。

旧 #38 からの変更点（重要）: **default 値の方針を「現行 main の設定値を維持」に変更した。**

- 旧 #38 の default は PR #32 の決定値（effort=medium 固定・1M 無効・auto-compact 65%）だったが、#32 は不採用クローズになった（判断記録は Issue #22）
- 本 PR では任意キー（`effortLevel` / `disable1m` / `autoCompactWindow`）を「変数未定義ならキー自体を出力しない」方式にし、`[data.claude]` を書かなければ**現行 main と同一の JSON** が生成される
- 1M 無効化などが必要なマシンだけ、`~/.config/chezmoi/chezmoi.toml` の `[data.claude]` で opt-in する

変更ファイル:

- `private_dot_claude/settings.json.tmpl` — `dig` フォールバック + 条件付きキー出力
- `.chezmoi.toml.tmpl` — `[data.claude]` のコメント付き設定例
- `CLAUDE.md` — 上書き変数の一覧表と 1M / auto-compact の依存関係の注意

## テスト計画

- [x] 変数未定義時のレンダリングが main の現行テンプレート出力と**完全一致**（`chezmoi execute-template` + `jq -S` diff で検証済み）
- [x] `[data.claude]` 全変数定義時に、各キーが正しい値で出力される（一時 config を `--config` で渡して検証済み）
- [x] 出力が valid JSON（`jq` 通過）

Refs #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Claude Code の設定を、マシンごと・個人ごとに上書きできる運用を追加しました。未設定の場合は従来どおりの既定値が適用されます。
  * 必要な項目だけ設定でき、未定義の値は出力されません（環境変数による上書きも対応）。

* **ドキュメント**
  * 既定値、上書き方法、設定値の整合条件（自動圧縮や 1M 無効化など）を詳しく説明しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->