### PR TITLE
fix(self-review): Codex レビューのモデル指定を gpt-5.5 に修正

### DIFF
--- a/private_dot_claude/skills/self-review/SKILL.md
+++ b/private_dot_claude/skills/self-review/SKILL.md
@@ -382,7 +382,7 @@ git commit -m "refactor: self-review (simplify + review fixes)"
 | Gemini プリフライトが unavailable | `--with-gemini` 指定下で容量不足や CLI 未応答 | Gemini を利用可能リストから除外し、クールダウンを 15 分保持。自動で Codex フォールバックは行わないため、必要なら `--with-gemini` を外して再実行する |
 | Gemini 429 (MODEL_CAPACITY_EXHAUSTED) | サーバー容量不足 | scripts/gemini-review.sh が 1 回リトライ → モデルフォールバック → クールダウン記録し、`[self-review] gemini unavailable...` を返して終了。呼び出し側は `--with-gemini` を外すか手動続行で対応する |
 | Codex レート制限 | 5時間ウィンドウ超過 | 次のレビュアー (Claude-p) へフォールバック。Simplify を Codex に委譲する `--simplify-via=codex` は特にレートを食う |
-| Codex `--output-schema` 違反 | gpt-5-codex モデルでツール起動時に schema が無視される既知バグ | `gpt-5` モデル指定 / `--output-last-message` の組合せで回避。Schema 違反検出時は Claude-p フォールバック |
+| Codex `--output-schema` 違反 | gpt-5-codex 系モデルでツール起動時に schema が無視される既知バグ | `-c model=gpt-5.5`（default、`CODEX_REVIEW_MODEL` で上書き可）+ `--output-last-message` の組合せで回避。Schema 違反検出時は Claude-p フォールバック |
 | Claude-p タイムアウト | ネットワークまたはAPI負荷 | 120秒タイムアウトで次のレビュアーへ |
 | ultrareview 失敗 (`exit 1`) | 課金枠超過 / API 障害 | 通常の `claude -p --bare` にフォールバック |
 | 全レビュアー失敗 | 全CLIが利用不可 | ユーザーに報告、Simplify 結果のみで判断を仰ぐ |

--- a/private_dot_claude/skills/self-review/docs/improvement-ideas.md
+++ b/private_dot_claude/skills/self-review/docs/improvement-ideas.md
@@ -200,7 +200,7 @@ fallback (primary が失敗した場合):
 - Gemini を **デフォルト経路から完全除外**。`--with-gemini` 指定時のみプリフライトも含めて起動
 - 全 CLI 呼び出しに **再現性確保フラグを必須化**:
   - `claude -p`: `--bare --output-format json --json-schema <FINDING_SCHEMA>`
-  - `codex exec`: `--output-schema <FINDING_SCHEMA> --ignore-user-config --ignore-rules`、モデルは `gpt-5`（`gpt-5-codex` の schema 無視バグ回避）
+  - `codex exec`: `--output-schema <FINDING_SCHEMA> --ignore-user-config --ignore-rules`、モデルは `-c model=gpt-5.5`（`gpt-5-codex` 系の schema 無視バグ回避。`gpt-5` は ChatGPT アカウント認証で 400 のため不可）
   - `claude ultrareview`: `--json` 必須、exit code を尊重
 - judgment 上限を 5 → **3 件** に。4 件目以降は info 格下げ
 - 新設: `references/schemas/finding-schema.json`（claude -p / codex exec 両用の出力スキーマ）

--- a/private_dot_claude/skills/self-review/references/review-prompts.md
+++ b/private_dot_claude/skills/self-review/references/review-prompts.md
@@ -132,7 +132,7 @@ Gemini は `--with-gemini` 指定時のみ経路に入る。
 - **`scripts/codex-review.sh`（内部で `codex exec` を実行）**: **Bash から `codex exec` を直接叩かない**（PreToolUse フック `block-codex-direct.py` にブロックされる）。呼び出しは [../scripts/codex-review.sh](../scripts/codex-review.sh) を経由する（スクリプトファイルの呼び出しは同フックの検査対象外）
   - スクリプト内部でサブコマンドは `exec` を使う（`exec review` は `--output-schema` を未サポート）、`--output-schema`、`--output-last-message <tmpfile>`、`--sandbox read-only` を組み立てる
   - `codex >= 0.122` 環境では `--ignore-user-config --ignore-rules` もスクリプト内部の判定で追加する（旧 `$CODEX_REPRO_FLAGS`、判定ロジックは Step 0 からスクリプトへ移設済み）
-  - 既知のバグ回避のため `--model gpt-5`（`gpt-5-codex` ではない）を推奨
+  - モデルはスクリプトが `-c model=`（default: `gpt-5.5`、環境変数 `CODEX_REVIEW_MODEL` で上書き可）で明示する。`--model gpt-5` と旧既定 `gpt-5.3-codex` は ChatGPT アカウント認証だと 400 で拒否されるため使わない（2026-07 実測）
   - レビュー指示は `--output-schema` 用プロンプト本文に「以下の diff をレビューせよ」と明示して埋め込む
 - **`claude ultrareview`**: `--json` を必須化。exit code 0=完了 / 1=失敗 / 130=Ctrl-C を尊重し、stdout のみパース対象とする
 
@@ -415,9 +415,12 @@ fi
 
 ### モデル選定の注意
 
-`gpt-5-codex` モデルは `--json` / `--output-schema` がツール起動時に無視される既知バグあり
+`gpt-5-codex` 系モデルは `--json` / `--output-schema` がツール起動時に無視される既知バグあり
 （[openai/codex#15451](https://github.com/openai/codex/issues/15451)）。
-スキーマ強制が要求される本スキルでは **`--model gpt-5`** を指定する。
+また `--model gpt-5` と旧既定 `gpt-5.3-codex` は ChatGPT アカウント認証だと
+400 invalid_request_error で拒否される（2026-07 実測）。
+スキーマ強制が要求される本スキルでは **`-c model=gpt-5.5`**（CLI 明示指定。
+`--ignore-user-config` 併用時も有効）を使う。上書きは環境変数 `CODEX_REVIEW_MODEL`。
 
 ### 出力フォーマット
 

--- a/private_dot_claude/skills/self-review/scripts/executable_codex-review.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_codex-review.sh
@@ -8,9 +8,15 @@
 #   そのため codex exec の呼び出しはこのスクリプト内に閉じ込める。
 # - スキーマ強制（--output-schema）付きで codex exec を実行し、finding-schema.json 準拠の
 #   JSON を stdout に出力する（--output-schema 非対応の `codex exec review` は使わない）。
-# - --model gpt-5 を明示する。--ignore-user-config で config.toml のモデル設定も無視されるため、
-#   未指定だと CLI 既定の gpt-5-codex に落ち、--output-schema が無視される既知バグ
-#   （openai/codex#15451）でスキーマ強制が黙って効かなくなる。
+# - モデルは `-c model=`（CLI 明示指定）で渡す。--ignore-user-config が付いても -c は効く。
+#   default は gpt-5.5（環境変数 CODEX_REVIEW_MODEL で上書き可）。モデル指定が必要な理由:
+#   - --ignore-user-config は config.toml のモデル設定も無視するため、未指定だと CLI 既定
+#     モデルに落ちる。gpt-5-codex 系は --output-schema がツール起動時に無視される既知バグ
+#     （openai/codex#15451）があり、スキーマ強制が黙って効かなくなる。
+#   - `--model gpt-5` と旧既定 gpt-5.3-codex は ChatGPT アカウント認証だと
+#     400 invalid_request_error で拒否される（2026-07 実測）。
+# - codex exec は git リポジトリ内（trusted directory）を cwd にして実行すること。
+#   リポジトリ外から呼ぶと "Not inside a trusted directory" で失敗する。
 #
 # Usage:
 #   cat <<'EOF' | bash codex-review.sh <schema-path> <prompt-body-file>
@@ -33,6 +39,8 @@
 #   1 - 依存コマンド不足 / 引数不足 / codex 実行失敗
 
 set -uo pipefail
+
+CODEX_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.5}"
 
 if ! command -v codex >/dev/null 2>&1; then
   >&2 echo "[self-review] codex CLI が見つかりません。security/design 観点は他レビュアーにフォールバックしてください"
@@ -81,7 +89,7 @@ trap 'rm -f "$TMP"' EXIT
   cat -
   echo '```'
 } | codex exec \
-  --model gpt-5 \
+  -c model="$CODEX_MODEL" \
   -c model_reasoning_effort=high \
   --output-schema "$SCHEMA" \
   --output-last-message "$TMP" \


### PR DESCRIPTION
## 概要

self-review の Codex ラッパー（`scripts/codex-review.sh`）のモデル指定を直す。PR #35 で入れた `--model gpt-5` は ChatGPT アカウント認証の Codex では 400 invalid_request_error で拒否され、`--ignore-user-config` 併用時は旧既定 gpt-5.3-codex も拒否されることが、PR #44 の self-review 実行中に実測で判明した。

- モデル指定を `-c model=gpt-5.5`（CLI 明示。`--ignore-user-config` 併用時も有効）に変更。環境変数 `CODEX_REVIEW_MODEL` で上書き可
- 「git リポジトリ内（trusted directory）で実行する」制約をヘッダーに追記
- 参照ドキュメント 3 箇所（review-prompts.md / SKILL.md / improvement-ideas.md）の gpt-5 推奨記述を追従更新

## テスト計画

- [x] `bash -n` 構文チェック
- [x] 実機スモークテスト（gpt-5.5 で codex exec 成功、finding-schema 準拠 JSON を出力）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Codex実行時の既知のスキーマ違反への対処手順を更新し、推奨モデルの既定を `gpt-5.5` に変更しました。
  * 必要に応じて環境変数でモデル指定を上書きできるようになりました。
  * スキーマ違反検出時はClaude-pへ切り替える案内を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->