### PR TITLE
chore(nvim): lazy-lock.json のターゲット側更新を取り込み

### DIFF
--- a/dot_config/nvim/lazy-lock.json
+++ b/dot_config/nvim/lazy-lock.json
@@ -31,6 +31,7 @@
   "nvim-treesitter-textobjects": { "branch": "main", "commit": "a0e182ae21fda68c59d1f36c9ed45600aef50311" },
   "nvim-ts-autotag": { "branch": "main", "commit": "8e1c0a389f20bf7f5b0dd0e00306c1247bda2595" },
   "nvim-web-devicons": { "branch": "master", "commit": "746ffbb17975ebd6c40142362eee1b0249969c5c" },
+  "obsidian.nvim": { "branch": "main", "commit": "2a8af7bd141123c7911fd0956ad986f29fe5bf12" },
   "oil.nvim": { "branch": "master", "commit": "f55b25e493a7df76371cfadd0ded5004cb9cd48a" },
   "persistence.nvim": { "branch": "main", "commit": "b20b2a7887bd39c1a356980b45e03250f3dce49c" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },


### PR DESCRIPTION
## 概要

Neovim プラグインの lockfile（`lazy-lock.json`）がターゲット側（実機のプラグイン更新）で進んでいたため、`chezmoi re-add` でソースに取り込む。放置すると次回 `chezmoi apply` でプラグインバージョンが巻き戻るため。

## テスト計画

- lockfile のみの変更（コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)