### PR TITLE
fix: statusline が空白になる 4 経路の解消（幅フォールバック / exit 0 保証 / PR 取得の非同期化）

### DIFF
--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -7,15 +7,16 @@ set -euo pipefail
 
 input=$(cat)
 
-# --- Terminal width guard ---
-# WezTerm pane split may report incorrect width before initialization.
-# Also skip during session startup (before first API response) since
-# Claude Code's TUI renderer may not have the correct dimensions yet.
-cols=${COLUMNS:-$(tput cols 2>/dev/null || echo 0)}
-(( cols < 30 )) && exit 0
-
-duration=$(echo "$input" | jq -r '.cost.total_duration_ms // 0' | cut -d. -f1)
-(( duration == 0 )) && exit 0
+# --- Terminal width ---
+# COLUMNS is set by Claude Code v2.1.153+. In environments where it's absent
+# (older Claude Code, or the shell has no TERM), `tput cols` doesn't work since
+# this script isn't attached to a terminal — so fall back to 80 instead of
+# calling tput. Never exit early on a small/unknown width: narrow layout
+# renders a short single row, so there's no reason to blank the whole bar.
+cols="${COLUMNS:-}"
+if [[ -z "$cols" || ! "$cols" =~ ^[0-9]+$ || "$cols" -eq 0 ]]; then
+  cols=80
+fi
 
 # --- Extract fields via jq ---
 project_dir=$(echo "$input" | jq -r '.workspace.project_dir // empty')
@@ -44,32 +45,88 @@ if [[ -n "$project_dir" && ( -d "$project_dir/.git" || -f "$project_dir/.git" ) 
   fi
 fi
 
-# --- Open PR for current branch (cached per branch, 60s TTL) ---
+# --- Open PR for current branch (read cache only; never blocks the render path) ---
 # Replicates the open-PR indicator Claude Code's default statusline used to show.
-# gh is a network call, so cache aggressively and guard every read (set -euo pipefail safe).
+# gh is a blocking network call, so it never runs inline here. A detached background
+# job refreshes the cache; this script only reads whatever is already on disk, even
+# if stale — a stale PR badge beats no statusline at all.
+refresh_pr_cache() {
+  local proj_dir="$1" br="$2" cfile="$3"
+  local pcache="${cfile}.pr"
+  local lock_dir="${pcache}.lock"
+  local now_ts
+  now_ts=$(date +%s)
+
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    local lock_age
+    lock_age=$(( now_ts - $(stat -f %m "$lock_dir" 2>/dev/null || stat -c %Y "$lock_dir" 2>/dev/null || echo "$now_ts") ))
+    if (( lock_age > 120 )); then
+      rmdir "$lock_dir" 2>/dev/null || true
+      mkdir "$lock_dir" 2>/dev/null || return 0
+    else
+      return 0
+    fi
+  fi
+  # Expand lock_dir into the trap string now, not at fire time — it's a local
+  # variable that goes out of scope once this function returns, and under
+  # `set -u` a delayed `$lock_dir` reference at EXIT would be unbound.
+  # shellcheck disable=SC2064
+  trap "rmdir '$lock_dir' 2>/dev/null || true" EXIT
+
+  local -a timeout_prefix=(env)
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_prefix=(timeout 10)
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_prefix=(gtimeout 10)
+  fi
+
+  local err_file
+  err_file=$(mktemp)
+  local pr_json="" gh_exit=0
+  pr_json=$(cd "$proj_dir" && "${timeout_prefix[@]}" gh pr view --json number,url,state 2>"$err_file") || gh_exit=$?
+  local err_content
+  err_content=$(cat "$err_file" 2>/dev/null || echo "")
+  rm -f "$err_file"
+
+  local new_number="" new_url=""
+  if (( gh_exit == 0 )); then
+    local state
+    state=$(echo "$pr_json" | jq -r '.state // empty' 2>/dev/null || echo "")
+    if [[ "$state" == "OPEN" ]]; then
+      new_number=$(echo "$pr_json" | jq -r '.number' 2>/dev/null || echo "")
+      new_url=$(echo "$pr_json" | jq -r '.url' 2>/dev/null || echo "")
+    fi
+  elif echo "$err_content" | grep -qi "no pull requests found"; then
+    new_number=""; new_url=""
+  else
+    # Transient failure (network, auth, etc.) — keep whatever PR value was cached
+    # before and only bump the timestamp, so we retry in 60s without blanking the badge.
+    if [[ -f "$pcache" ]]; then
+      new_number=$(sed -n '3p' "$pcache" 2>/dev/null || echo "")
+      new_url=$(sed -n '4p' "$pcache" 2>/dev/null || echo "")
+    fi
+  fi
+
+  local tmp_file="${pcache}.tmp.$$"
+  printf '%s\n%s\n%s\n%s\n' "$now_ts" "$br" "$new_number" "$new_url" > "$tmp_file"
+  mv -f "$tmp_file" "$pcache"
+}
+
 pr_number=""; pr_url=""
 if [[ -n "$branch" && -n "$project_dir" ]] && command -v gh >/dev/null 2>&1; then
   pr_cache="${cache_file}.pr"
-  use_pr_cache=""
+  need_refresh=1
   if [[ -f "$pr_cache" ]]; then
     pr_ctime=$(sed -n '1p' "$pr_cache" 2>/dev/null || echo 0); pr_ctime=${pr_ctime//[^0-9]/}; pr_ctime=${pr_ctime:-0}
     pr_cbranch=$(sed -n '2p' "$pr_cache" 2>/dev/null || echo "")
-    if [[ "$pr_cbranch" == "$branch" ]] && (( now - pr_ctime < 60 )); then
+    if [[ "$pr_cbranch" == "$branch" ]]; then
       pr_number=$(sed -n '3p' "$pr_cache" 2>/dev/null || echo "")
       pr_url=$(sed -n '4p' "$pr_cache" 2>/dev/null || echo "")
-      use_pr_cache=1
+      (( now - pr_ctime < 60 )) && need_refresh=0
     fi
   fi
-  if [[ -z "$use_pr_cache" ]]; then
-    pr_line=$( (cd "$project_dir" && gh pr view --json number,url,state 2>/dev/null) \
-      | jq -r 'select(.state=="OPEN") | "\(.number)\t\(.url)"' 2>/dev/null || true )
-    if [[ "$pr_line" == *$'\t'* ]]; then
-      pr_number="${pr_line%%$'\t'*}"
-      pr_url="${pr_line#*$'\t'}"
-    else
-      pr_number=""; pr_url=""
-    fi
-    printf '%s\n%s\n%s\n%s\n' "$now" "$branch" "$pr_number" "$pr_url" > "$pr_cache"
+  if (( need_refresh )); then
+    ( refresh_pr_cache "$project_dir" "$branch" "$cache_file" ) >/dev/null 2>&1 &
   fi
 fi
 
@@ -177,4 +234,7 @@ else
 fi
 
 printf '%b\n' "$line1"
-[[ -n "$line2" ]] && printf '%b\n' "$line2"
+if [[ -n "$line2" ]]; then
+  printf '%b\n' "$line2"
+fi
+exit 0

--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -50,10 +50,22 @@ fi
 # gh is a blocking network call, so it never runs inline here. A detached background
 # job refreshes the cache; this script only reads whatever is already on disk, even
 # if stale — a stale PR badge beats no statusline at all.
+
+# Read line N from a PR cache file (empty string if the file or line is missing).
+pr_cache_line() {
+  sed -n "${1}p" "$2" 2>/dev/null || true
+}
+
 refresh_pr_cache() {
   local proj_dir="$1" br="$2" cfile="$3"
   local pcache="${cfile}.pr"
-  local lock_dir="${pcache}.lock"
+  # Not `local`: this function only ever runs inside its own backgrounded
+  # process, so leaving it in the process-global scope is safe, and it lets
+  # the EXIT trap below reference it by name (single-quoted, expanded at fire
+  # time) instead of splicing the path into the trap string — untrusted path
+  # bytes (quotes, shell metacharacters) in a double-quoted trap would be
+  # re-parsed as shell syntax at signal time (CWE-78).
+  lock_dir="${pcache}.lock"
   local now_ts
   now_ts=$(date +%s)
 
@@ -67,12 +79,14 @@ refresh_pr_cache() {
       return 0
     fi
   fi
-  # Expand lock_dir into the trap string now, not at fire time — it's a local
-  # variable that goes out of scope once this function returns, and under
-  # `set -u` a delayed `$lock_dir` reference at EXIT would be unbound.
-  # shellcheck disable=SC2064
-  trap "rmdir '$lock_dir' 2>/dev/null || true" EXIT
+  # ${lock_dir:-} keeps this safe under `set -u` even if the trap somehow
+  # fires before lock_dir is assigned; rmdir on an empty/missing path just
+  # fails and `|| true` swallows it.
+  trap 'rmdir "${lock_dir:-}" 2>/dev/null || true' EXIT
 
+  # `env` is a no-op prefix used when no timeout binary is found. Kept as a
+  # non-empty array element on purpose: macOS ships bash 3.2, where `set -u`
+  # treats expanding an empty array as an unbound-variable error.
   local -a timeout_prefix=(env)
   if command -v timeout >/dev/null 2>&1; then
     timeout_prefix=(timeout 10)
@@ -80,31 +94,31 @@ refresh_pr_cache() {
     timeout_prefix=(gtimeout 10)
   fi
 
-  local err_file
-  err_file=$(mktemp)
+  # `gh pr list` (unlike `gh pr view`) exits 0 with `[]` when there's no open
+  # PR for the branch, so a missing PR and a failed call are cleanly distinguished
+  # by exit code alone — no stderr text matching needed. `--head` only matches
+  # on branch name, so a same-named fork branch's cross-repository PR would
+  # otherwise be shown as our own; fetch a few candidates (limit 1 would already
+  # cut the list before we can filter) and exclude isCrossRepository ones. If we
+  # only ever open PRs from a fork ourselves, our badge simply won't show — an
+  # accepted trade-off for not misattributing someone else's PR.
   local pr_json="" gh_exit=0
-  pr_json=$(cd "$proj_dir" && "${timeout_prefix[@]}" gh pr view --json number,url,state 2>"$err_file") || gh_exit=$?
-  local err_content
-  err_content=$(cat "$err_file" 2>/dev/null || echo "")
-  rm -f "$err_file"
+  pr_json=$(cd "$proj_dir" && "${timeout_prefix[@]}" gh pr list --head "$br" --state open --json number,url,isCrossRepository --limit 10 2>/dev/null) || gh_exit=$?
 
   local new_number="" new_url=""
   if (( gh_exit == 0 )); then
-    local state
-    state=$(echo "$pr_json" | jq -r '.state // empty' 2>/dev/null || echo "")
-    if [[ "$state" == "OPEN" ]]; then
-      new_number=$(echo "$pr_json" | jq -r '.number' 2>/dev/null || echo "")
-      new_url=$(echo "$pr_json" | jq -r '.url' 2>/dev/null || echo "")
+    local line
+    line=$(echo "$pr_json" | jq -r '[.[] | select(.isCrossRepository | not)] | if length > 0 then "\(.[0].number)\t\(.[0].url)" else "" end' 2>/dev/null || echo "")
+    if [[ "$line" == *$'\t'* ]]; then
+      new_number="${line%%$'\t'*}"
+      new_url="${line#*$'\t'}"
     fi
-  elif echo "$err_content" | grep -qi "no pull requests found"; then
-    new_number=""; new_url=""
-  else
-    # Transient failure (network, auth, etc.) — keep whatever PR value was cached
-    # before and only bump the timestamp, so we retry in 60s without blanking the badge.
-    if [[ -f "$pcache" ]]; then
-      new_number=$(sed -n '3p' "$pcache" 2>/dev/null || echo "")
-      new_url=$(sed -n '4p' "$pcache" 2>/dev/null || echo "")
-    fi
+  elif [[ -f "$pcache" ]] && [[ "$(pr_cache_line 2 "$pcache")" == "$br" ]]; then
+    # Transient failure (network, auth, etc.) — keep the cached PR value, but
+    # only when it belongs to this same branch, so we retry in 60s without
+    # blanking the badge and never carry a stale branch's PR into this one.
+    new_number=$(pr_cache_line 3 "$pcache")
+    new_url=$(pr_cache_line 4 "$pcache")
   fi
 
   local tmp_file="${pcache}.tmp.$$"
@@ -117,16 +131,16 @@ if [[ -n "$branch" && -n "$project_dir" ]] && command -v gh >/dev/null 2>&1; the
   pr_cache="${cache_file}.pr"
   need_refresh=1
   if [[ -f "$pr_cache" ]]; then
-    pr_ctime=$(sed -n '1p' "$pr_cache" 2>/dev/null || echo 0); pr_ctime=${pr_ctime//[^0-9]/}; pr_ctime=${pr_ctime:-0}
-    pr_cbranch=$(sed -n '2p' "$pr_cache" 2>/dev/null || echo "")
+    pr_ctime=$(pr_cache_line 1 "$pr_cache"); pr_ctime=${pr_ctime//[^0-9]/}; pr_ctime=${pr_ctime:-0}
+    pr_cbranch=$(pr_cache_line 2 "$pr_cache")
     if [[ "$pr_cbranch" == "$branch" ]]; then
-      pr_number=$(sed -n '3p' "$pr_cache" 2>/dev/null || echo "")
-      pr_url=$(sed -n '4p' "$pr_cache" 2>/dev/null || echo "")
+      pr_number=$(pr_cache_line 3 "$pr_cache")
+      pr_url=$(pr_cache_line 4 "$pr_cache")
       (( now - pr_ctime < 60 )) && need_refresh=0
     fi
   fi
   if (( need_refresh )); then
-    ( refresh_pr_cache "$project_dir" "$branch" "$cache_file" ) >/dev/null 2>&1 &
+    refresh_pr_cache "$project_dir" "$branch" "$cache_file" >/dev/null 2>&1 &
   fi
 fi
 
@@ -234,7 +248,5 @@ else
 fi
 
 printf '%b\n' "$line1"
-if [[ -n "$line2" ]]; then
-  printf '%b\n' "$line2"
-fi
+[[ -n "$line2" ]] && printf '%b\n' "$line2"
 exit 0

--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -14,8 +14,13 @@ input=$(cat)
 # calling tput. Never exit early on a small/unknown width: narrow layout
 # renders a short single row, so there's no reason to blank the whole bar.
 cols="${COLUMNS:-}"
-if [[ -z "$cols" || ! "$cols" =~ ^[0-9]+$ || "$cols" -eq 0 ]]; then
+if [[ ! "$cols" =~ ^[0-9]+$ ]]; then
   cols=80
+else
+  # Force base-10: a value like "08"/"09" is decimal here but would trip bash's
+  # octal parser in later `(( ))` arithmetic ("value too great for base").
+  cols=$((10#$cols))
+  (( cols == 0 )) && cols=80
 fi
 
 # --- Extract fields via jq ---
@@ -152,14 +157,20 @@ refresh_pr_cache() {
   # fails and `|| true` swallows it.
   trap 'rmdir "${lock_dir:-}" 2>/dev/null || true' EXIT
 
-  # `env` is a no-op prefix used when no timeout binary is found. Kept as a
-  # non-empty array element on purpose: macOS ships bash 3.2, where `set -u`
-  # treats expanding an empty array as an unbound-variable error.
+  # Bound the gh call so a stalled network request can't leave an unbounded
+  # background process holding the lock (later renders would take the stale lock
+  # after 120s and spawn *another* gh, accumulating hung processes). `perl`'s
+  # SIGALRM idiom survives exec and is present on stock macOS/Linux, so the bare
+  # `env` no-op only remains as a last resort when even perl is missing. `env`
+  # is kept as a non-empty array element on purpose: macOS ships bash 3.2, where
+  # `set -u` treats expanding an empty array as an unbound-variable error.
   local -a timeout_prefix=(env)
   if command -v timeout >/dev/null 2>&1; then
     timeout_prefix=(timeout 10)
   elif command -v gtimeout >/dev/null 2>&1; then
     timeout_prefix=(gtimeout 10)
+  elif command -v perl >/dev/null 2>&1; then
+    timeout_prefix=(perl -e 'alarm shift; exec @ARGV' 10)
   fi
 
   # `gh pr list` (unlike `gh pr view`) exits 0 with `[]` when there's no open

--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -25,25 +25,93 @@ model=$(echo "$input" | jq -r '.model.display_name // "?"')
 used=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
 cost=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 
+# Secondary fields, fetched in one jq call to keep render-path process count low.
+# Space-joined single line; "-" marks an absent value (no field ever contains a
+# space, so a plain `read` split is safe). Order must match the read below.
+extras=$(echo "$input" | jq -r '[
+  (.effort.level // "-"),
+  ((.fast_mode // false) | tostring),
+  ((.exceeds_200k_tokens // false) | tostring),
+  ((.context_window.total_input_tokens // 0) | floor | tostring),
+  ((.context_window.context_window_size // 0) | floor | tostring),
+  ((.cost.total_lines_added // 0) | floor | tostring),
+  ((.cost.total_lines_removed // 0) | floor | tostring),
+  ((.cost.total_duration_ms // 0) | floor | tostring),
+  ((.rate_limits.five_hour.used_percentage // "-") | tostring),
+  ((.rate_limits.five_hour.resets_at // "-") | tostring),
+  ((.rate_limits.seven_day.used_percentage // "-") | tostring),
+  ((.rate_limits.seven_day.resets_at // "-") | tostring)
+] | join(" ")' 2>/dev/null) || extras=""
+[[ -n "$extras" ]] || extras='- false false 0 0 0 0 0 - - - -'
+read -r effort_level fast_mode over200k tokens_in win_size lines_add lines_del dur_ms five_h rl5_reset seven_d rl7_reset <<EOF
+$extras
+EOF
+[[ "$effort_level" == "-" ]] && effort_level=""
+[[ "$five_h" == "-" ]] && five_h=""
+[[ "$rl5_reset" == "-" ]] && rl5_reset=""
+[[ "$seven_d" == "-" ]] && seven_d=""
+[[ "$rl7_reset" == "-" ]] && rl7_reset=""
+
+# 97242 -> 97k, 1000000 -> 1M (token counts and context-window sizes)
+fmt_tokens() {
+  if (( $1 >= 1000000 )); then printf '%dM' $(( $1 / 1000000 ))
+  elif (( $1 >= 1000 )); then printf '%dk' $(( $1 / 1000 ))
+  else printf '%d' "$1"
+  fi
+}
+
+fmt_duration() {
+  local ms="$1" total_mins hours mins
+  (( ms > 0 )) || return 0
+  total_mins=$(( ms / 60000 ))
+  (( total_mins > 0 )) || total_mins=1
+  if (( total_mins < 60 )); then
+    printf '%dm' "$total_mins"
+  else
+    hours=$(( total_mins / 60 ))
+    mins=$(( total_mins % 60 ))
+    printf '%dh%02dm' "$hours" "$mins"
+  fi
+}
+
+reset_hm() {
+  local ts="${1%%.*}"
+  [[ "$ts" =~ ^[0-9]+$ ]] || return 0
+  date -r "$ts" +%H:%M 2>/dev/null || date -d "@$ts" +%H:%M 2>/dev/null || true
+}
+
 # --- Git branch (cached per project, 5s TTL) ---
 cache_dir="/tmp/claude-statusline"
 mkdir -p "$cache_dir"
 cache_file="$cache_dir/$(echo "$project_dir" | tr '/' '_')"
 now=$(date +%s)
 
-branch=""
+# Cache format: line1=timestamp line2=branch line3=dirty(1/0). Older 2-line
+# caches yield an empty dirty flag -> treated as unknown, rendered unmarked.
+branch=""; dirty_flag=""
 if [[ -n "$project_dir" && ( -d "$project_dir/.git" || -f "$project_dir/.git" ) ]]; then
   if [[ -f "$cache_file" ]]; then
     cached_time=$(head -1 "$cache_file")
+    cached_time=${cached_time//[^0-9]/}; cached_time=${cached_time:-0}
     if (( now - cached_time < 5 )); then
-      branch=$(tail -1 "$cache_file")
+      branch=$(sed -n 2p "$cache_file")
+      dirty_flag=$(sed -n 3p "$cache_file")
     fi
   fi
   if [[ -z "$branch" ]]; then
     branch=$(git -C "$project_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-    printf '%s\n%s\n' "$now" "$branch" > "$cache_file"
+    dirty_flag=0
+    if [[ -n "$branch" ]]; then
+      # Tracked files only (-uno): keeps the check cheap and stops untracked
+      # noise (build artifacts etc.) from lighting the marker.
+      dirty_out=$(git -C "$project_dir" status --porcelain -uno 2>/dev/null || true)
+      [[ -n "$dirty_out" ]] && dirty_flag=1
+    fi
+    printf '%s\n%s\n%s\n' "$now" "$branch" "$dirty_flag" > "$cache_file"
   fi
 fi
+branch_disp="$branch"
+[[ "$dirty_flag" == "1" ]] && branch_disp="${branch}*"
 
 # --- Open PR for current branch (read cache only; never blocks the render path) ---
 # Replicates the open-PR indicator Claude Code's default statusline used to show.
@@ -171,44 +239,75 @@ cost_fmt=$(printf '$%.2f' "$cost")
 # Thresholds overridable via env. All reads are guarded for absence (set -euo pipefail safe).
 RL_WARN=${CLAUDE_RL_WARN:-80}   # yellow gauge
 RL_CRIT=${CLAUDE_RL_CRIT:-90}   # red + macOS notification ("switch account")
-rl_full=""; rl_short=""
-five_h=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
-seven_d=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+rl_short=""; rl_wide=""
 rl_max=0; rl_label=""; rl_reset=""
 if [[ -n "$five_h" ]]; then
-  v=${five_h%%.*}; v=${v:-0}; rl_max=$v; rl_label="5h"
-  rl_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+  v=${five_h%%.*}; v=${v:-0}; rl_max=$v; rl_label="5h"; rl_reset="$rl5_reset"
 fi
 if [[ -n "$seven_d" ]]; then
   v=${seven_d%%.*}; v=${v:-0}
   if (( v > rl_max )); then
-    rl_max=$v; rl_label="7d"
-    rl_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+    rl_max=$v; rl_label="7d"; rl_reset="$rl7_reset"
   fi
+fi
+
+# Wide shows BOTH windows, each colored by its own severity; once a window
+# crosses the warn threshold its reset time is attached.
+rl_pair() {
+  local p=${2%%.*}; p=${p:-0}
+  local color hm seg
+  [[ "$p" =~ ^[0-9]+$ ]] || p=0
+  if (( p >= RL_CRIT )); then color="31;1"
+  elif (( p >= RL_WARN )); then color="33"
+  else color="32"
+  fi
+  seg="\033[${color}m${1}:${p}%\033[0m"
+  if (( p >= RL_WARN )) && [[ -n "$3" ]]; then
+    hm=$(reset_hm "$3")
+    [[ -n "$hm" ]] && seg+="\033[2m(→${hm})\033[0m"
+  fi
+  printf '%s' "$seg"
+}
+[[ -n "$five_h" ]] && rl_wide="$(rl_pair 5h "$five_h" "$rl5_reset")"
+if [[ -n "$seven_d" ]]; then
+  [[ -n "$rl_wide" ]] && rl_wide+=" "
+  rl_wide+="$(rl_pair 7d "$seven_d" "$rl7_reset")"
 fi
 if [[ -n "$rl_label" ]]; then
   if (( rl_max >= RL_CRIT )); then
-    rl_full="\033[31;1m⚠ ${rl_label}:${rl_max}% 切替検討\033[0m"
     rl_short="\033[31;1m⚠${rl_max}%\033[0m"
     # Desktop notification — macOS only, debounced once per reset window, backgrounded
     if [[ "$(uname)" == "Darwin" && -n "$rl_reset" ]]; then
       flag="$cache_dir/rl-notified-${rl_reset%%.*}"
       if [[ ! -f "$flag" ]]; then
-        hm=$(date -r "${rl_reset%%.*}" +%H:%M 2>/dev/null || echo "?")
+        hm=$(reset_hm "$rl_reset"); hm=${hm:-?}
         ( osascript -e "display notification \"${rl_label} 使用率 ${rl_max}%。${hm} にリセット。別アカウントへの切替を検討してください\" with title \"Claude Code rate limit\" sound name \"Sosumi\"" >/dev/null 2>&1 & )
         : > "$flag"
       fi
     fi
   elif (( rl_max >= RL_WARN )); then
-    rl_full="\033[33m${rl_label}:${rl_max}%\033[0m"; rl_short="\033[33m${rl_max}%\033[0m"
+    rl_short="\033[33m${rl_max}%\033[0m"
   else
-    # Normal: show gauge on wide/medium only; keep narrow uncluttered
-    rl_full="\033[32m${rl_label}:${rl_max}%\033[0m"; rl_short=""
+    # Normal: wide shows detailed limits; narrow stays uncluttered.
+    rl_short=""
   fi
 fi
 
+token_window_seg=""
+if (( win_size > 0 )); then
+  token_window_seg=" ($(fmt_tokens "$tokens_in")/$(fmt_tokens "$win_size"))"
+fi
+model_seg="$model"
+[[ "$fast_mode" == "true" ]] && model_seg="⚡${model_seg}"
+[[ -n "$effort_level" ]] && model_seg+=" \033[2m·${effort_level}\033[0m"
+lines_seg=""
+if (( lines_add > 0 || lines_del > 0 )); then
+  lines_seg="\033[32m+${lines_add}\033[0m/\033[31m-${lines_del}\033[0m"
+fi
+duration_seg=$(fmt_duration "$dur_ms")
+
 # --- Compose lines (responsive; wide/medium render two rows) ---
-# Row 1 = identity (project | branch | PR), Row 2 = metrics (context | model | cost | rate-limit).
+# Row 1 = identity (project | branch | PR), Row 2 = metrics (context | model | cost | usage).
 # Narrow stays a single row. Using printf '%b' for reliable escape handling across shells.
 line1=""; line2=""
 if (( cols >= 90 )); then
@@ -223,23 +322,30 @@ if (( cols >= 90 )); then
 
   # Row 1: project | branch | PR
   line1="\033[36;1m${project}\033[0m"
-  [[ -n "$branch" ]] && line1+=" \033[2m|\033[0m \033[35m${branch}\033[0m"
+  [[ -n "$branch" ]] && line1+=" \033[2m|\033[0m \033[35m${branch_disp}\033[0m"
   [[ -n "$pr_seg" ]] && line1+=" \033[2m|\033[0m ${pr_seg}"
-  # Row 2: ▓▓▓░░ XX% | model $X.XX | rate-limit
+  # Row 2: ▓▓▓░░ XX% (tokens/window) | model | $X.XX | +/- | duration | rate-limits
   line2="\033[${bar_color}m${bar}\033[0m \033[${bar_color}m${used}%\033[0m"
-  line2+=" \033[2m|\033[0m ${model} \033[2m${cost_fmt}\033[0m"
-  [[ -n "$rl_full" ]] && line2+=" \033[2m|\033[0m ${rl_full}"
+  [[ "$over200k" == "true" ]] && line2+=" \033[31;1m⚠200k+\033[0m"
+  line2+="${token_window_seg}"
+  line2+=" \033[2m|\033[0m ${model_seg}"
+  line2+=" \033[2m|\033[0m ${cost_fmt}"
+  [[ -n "$lines_seg" ]] && line2+=" \033[2m|\033[0m ${lines_seg}"
+  [[ -n "$duration_seg" ]] && line2+=" \033[2m|\033[0m ${duration_seg}"
+  [[ -n "$rl_wide" ]] && line2+=" \033[2m|\033[0m ${rl_wide}"
 
 elif (( cols >= 60 )); then
   # Medium
   # Row 1: project | branch | PR
   line1="\033[36;1m${project}\033[0m"
-  [[ -n "$branch" ]] && line1+=" \033[2m|\033[0m \033[35m${branch}\033[0m"
+  [[ -n "$branch" ]] && line1+=" \033[2m|\033[0m \033[35m${branch_disp}\033[0m"
   [[ -n "$pr_seg" ]] && line1+=" \033[2m|\033[0m ${pr_seg}"
-  # Row 2: XX% | $X.XX | rate-limit
+  # Row 2: XX% | model | $X.XX | duration | rate-limit (warn/crit only)
   line2="\033[${bar_color}m${used}%\033[0m"
-  line2+=" \033[2m|\033[0m \033[2m${cost_fmt}\033[0m"
-  [[ -n "$rl_full" ]] && line2+=" \033[2m|\033[0m ${rl_full}"
+  line2+=" \033[2m|\033[0m ${model}"
+  line2+=" \033[2m|\033[0m ${cost_fmt}"
+  [[ -n "$duration_seg" ]] && line2+=" \033[2m|\033[0m ${duration_seg}"
+  [[ -n "$rl_short" ]] && line2+=" \033[2m|\033[0m ${rl_short}"
 
 else
   # Narrow: single row — project XX% $X.XX (rate-limit shown only when critical)


### PR DESCRIPTION
# 概要

Claude Code のステータスライン（`~/.claude/statusline.sh`）が「ワークスペース・コンテキスト % ・PR バッジが表示されないことが多い」問題の修正です。

Claude Code の公式仕様では、statusline スクリプトが **exit code 非 0、または stdout 空** だとステータスラインは空白になります（[公式ドキュメント](https://code.claude.com/docs/en/statusline)）。調査（仕様調査 / 動的再現テスト / 変更履歴・ログ調査の 3 系統）の結果、現行スクリプトに空白化を引き起こす経路が 4 つ実証されました。

## 原因と修正内容

| 原因（実証済み） | 修正 |
|---|---|
| `COLUMNS` 未設定時に `tput cols` へフォールバック → TTY 非接続のため常に失敗（公式に「動作しない」と明記）→ cols=0 → 無出力で exit | `tput` を廃止し、`COLUMNS` 未設定・非数値・0 のときは 80 にフォールバック。幅による早期 exit も廃止（narrow レイアウトで描画） |
| narrow 幅（30〜59 桁）のとき最終行の `[[ -n "$line2" ]] && printf` が **exit code 1** を返す → 出力があっても空白化 | 明示的な `exit 0` を末尾に追加し、全経路で exit 0 を保証 |
| `gh pr view` がタイムアウトなしのブロッキングネットワーク呼び出し（2026-06-17 追加）。遅延すると描画がキャンセルされ、失敗時も「PR なし」と区別せず 60 秒キャッシュ → PR バッジが出ない | PR 取得を完全非同期化。描画パスはキャッシュを読むだけにし、更新は lock 付きバックグラウンドジョブへ分離。`gh pr list` に切り替えて exit code だけで「PR なし」と「一時失敗」を区別し、一時失敗時は同一ブランチの旧値を保持 |
| セッション開始直後は `total_duration_ms==0` で意図的に非表示 | ガードを削除（`COLUMNS` が公式提供されるようになり、導入理由の「起動直後は幅が不正確」が消滅） |

## セルフレビュー結果

simplify 4 観点（reuse / simplification / efficiency / altitude）+ 外部レビュー 2 観点（bug=Codex / security=Codex）を実施し、以下を反映済みです。

- **security**: EXIT trap へのパス文字列埋め込みを排除（シングルクォート trap + 発火時展開、CWE-78 対策。攻撃パターンで実証のうえ修正確認済み）
- **bug**: `gh pr list --head` はブランチ名のみで照合するため、同名ブランチの fork PR を誤表示し得る → `isCrossRepository` で fork PR を除外（自分が fork から PR を出す運用ではバッジが出ない制約は許容）
- **simplify**: stderr 文言マッチの廃止・jq 起動の一本化・キャッシュ読み取りの共通関数化・二重 fork の解消 等

## スコープ外 / 留意点

- `timeout_prefix=(env)` の no-op プレフィックスは維持（macOS 標準 bash 3.2 では `set -u` + 空配列展開がエラーになるため。理由コメントを追記済み）
- Claude Code 本体がプロセスグループごと kill する実装だった場合のバックグラウンドジョブの挙動は実運用で要観察
- Linux の `stat -c` フォールバックは未検証（検証は macOS のみ）

# テスト計画

- [x] `bash -n` / `shellcheck`（指摘ゼロ）
- [x] COLUMNS なし（env -i）/ 0 / 25 / 50 / 80 / 120 の全ケースで exit 0・stdout 非空
- [x] `total_duration_ms` = 0 / 欠落、`context_window` 欠落、空 JSON `{}` で exit 0・stdout 非空
- [x] rate_limits 85% / 95%（critical）でゲージ表示・macOS 通知（1 回のみ）
- [x] git リポジトリの project_dir で描画 0.1 秒未満（gh はバックグラウンドに退避）
- [x] バックグラウンドジョブの PR キャッシュ更新・lock 解除・stale lock（120 秒超）奪取
- [x] gh モックで PR あり / なし / cross-repo のみ / gh 失敗（同一ブランチ旧値保持）の 4 ケース
- [x] 旧 PR キャッシュフォーマット（4 行形式）の読み取り互換
- [ ] マージ後 `chezmoi apply` で実機反映し、WezTerm ペイン分割・セッション起動直後・PR ありリポジトリで表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ターミナル幅の判定を見直し、欠落/不正/0 の場合は常に 80 カラムでステータスラインを安定表示。
  * プルリクエスト情報をバックグラウンド更新に変更し、TTL付きのキャッシュを同一ブランチで活用。
  * レート制限表示を表示形式ごとに最適化し、macOS の通知をリセット単位でデバウンス。
* **その他**
  * スクリプトの終了処理を明示化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->