### PR TITLE
fix(self-review): codex-review.sh の mktemp を末尾X化して並列実行の衝突を解消

### DIFF
--- a/private_dot_claude/skills/self-review/scripts/executable_codex-review.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_codex-review.sh
@@ -76,7 +76,12 @@ else
 fi
 
 umask 077
-TMP=$(mktemp "${TMPDIR:-/tmp}/self-review-codex.XXXXXX.json")
+# mktemp のテンプレートは X が末尾でないと macOS(BSD) では乱数化されず固定名になり、
+# 並列実行（bug / security の 2 観点同時起動）で "File exists" 衝突する。
+# 末尾 XXXXXX で作成してから .json へ rename する。
+TMP=$(mktemp "${TMPDIR:-/tmp}/self-review-codex.XXXXXX")
+mv "$TMP" "${TMP}.json"
+TMP="${TMP}.json"
 trap 'rm -f "$TMP"' EXIT
 
 >&2 echo "[self-review] Codex レビュー実行中..."


### PR DESCRIPTION
## 概要

self-review スキルの Codex ラッパー `codex-review.sh` で、一時ファイル作成に使う mktemp テンプレートを修正します。

### 問題

現行の `mktemp "${TMPDIR:-/tmp}/self-review-codex.XXXXXX.json"` は、**X が末尾にないテンプレート**のため macOS（BSD mktemp）では乱数化されず、固定名 `self-review-codex.XXXXXX.json` がそのまま作られます。この状態で self-review の bug / security 2 観点を並列起動すると、2 プロセス目以降が `mkstemp failed ... File exists` で失敗し、さらに `TMP` が空のまま `codex exec --output-last-message "$TMP"` に渡って `a value is required for '--output-last-message <FILE>'` で落ちます。

2026-07-17 の macaron Sprint-14 レビューのセルフレビュー実行で実際に発生し、security 観点が 3 回連続で失敗しました（1 回目の並列起動衝突 + 残骸ファイルによる再発）。

### 修正

末尾 `XXXXXX` で mktemp してから `.json` へ rename する方式に変更します。trap による削除対象は rename 後のパス（`$TMP`）を参照するため、後始末は従来どおり機能します。

## テスト計画

- [x] 修正版スクリプトで security 観点レビューを実行し、正常終了（exit 0・finding-schema 準拠 JSON 出力）を確認済み（2026-07-17、macaron Sprint-14 レビューのセルフレビューにて）
- [x] `chezmoi apply` でターゲット `~/.claude/skills/self-review/scripts/codex-review.sh` へ反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * macOSでレビュー処理を並列実行した際、一時ファイルの作成に失敗する問題を修正しました。
  * 一時ファイル名の衝突を回避し、処理の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->