### PR TITLE
fix(hooks): hook timeout を秒単位の妥当な値へ修正（5000→5/60）

### DIFF
--- a/dot_codex/hooks.json.tmpl
+++ b/dot_codex/hooks.json.tmpl
@@ -18,12 +18,12 @@
           {
             "type": "command",
             "command": "python3 '{{ .chezmoi.homeDir }}/.codex/hooks/notify.py'",
-            "timeout": 5000
+            "timeout": 5
           },
           {
             "type": "command",
             "command": "bash '{{ .chezmoi.homeDir }}/.codex/hooks/cleanup.sh'",
-            "timeout": 5000
+            "timeout": 60
           }
         ]
       }

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -183,12 +183,12 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/notify.py",
-            "timeout": 5000
+            "timeout": 5
           },
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/cleanup.sh",
-            "timeout": 5000
+            "timeout": 60
           }
         ]
       }
@@ -200,7 +200,7 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/notify.py",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -211,7 +211,7 @@
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/notify.py",
-            "timeout": 5000,
+            "timeout": 5,
             "once": true
           },
           {


### PR DESCRIPTION
## 概要

Codex / Claude Code の hook `timeout` を秒単位に合わせて修正する。

- hook の `timeout` は**秒**単位（Codex は既定 600 秒）。従来の `5000` は約 83 分で、既定すら超える意図しない値だった（ミリ秒を秒に取り違えた値と推測）。
- 対象を実処理時間に見合う値へ:
  - `notify.py`（afplay を投げて即終了）: `5000` → `5`
  - `cleanup.sh`（sqlite DELETE / VACUUM、busy_timeout 3000ms・VACUUM は 50MB 超のみ）: `5000` → `60`
- `block-codex-direct.py`（10 秒）・`precompact-snapshot.py` / `postcompact-reinject.py`（30 秒）は妥当なので変更なし。

### 変更ファイル

- `dot_codex/hooks.json.tmpl`: notify 5 / cleanup 60
- `private_dot_claude/settings.json.tmpl`: notify 5（Stop / Notification / PreCompact の 3 箇所）/ cleanup 60

Codex 側の `5000` は Claude 側からコピーされた同一の根なので、両方まとめて修正した。

## テスト計画

- `chezmoi apply` 後、`~/.codex/hooks.json` と `~/.claude/settings.json` が妥当な JSON であることを確認済み（`python3 -c "import json; json.load(...)"`）。
- レンダリング結果の各 hook timeout が意図した値（block=10 / notify=5 / cleanup=60 / precompact-snapshot=30 / postcompact-reinject=30）であることを確認済み。

### 補足（別途フォロー不要の確認事項）

- Codex の PreToolUse matcher `"Bash"` は `tool_name` にマッチし、シェル実行のツール名 `Bash` に正しく発火する（[OpenAI 公式 hooks ドキュメント](https://learn.chatgpt.com/docs/hooks)で確認）。block-codex-direct.py は機能しており、こちらは修正不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 終了時に実行される通知処理とクリーンアップ処理のタイムアウトを短縮しました。
  * 処理が長時間停止し続けるケースを減らし、終了処理の応答性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->