### PR TITLE
feat: Opus 品質プロファイル起動と env 系設定の見直し

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -104,8 +104,16 @@ function mdv() {
 # e.g. typing `./README.md` or `README.md` runs mdv on it
 alias -s md=mdv
 
-# Claude Code: effort high で起動（モデルは Default = Opus 4.7 1M context）
-alias claude='claude --effort high'
+# Opus 4.8 用の品質プロファイル起動（1M 無効 + auto-compact を約 130k で早期発火）
+# 背景: dotfiles Issue #66（Opus の捏造・parse error は長 context + extended thinking で悪化する）
+# 注意: env はプロセス起動時にのみ読まれる。Fable セッション内の /model 切り替えでは適用されない。
+#       Opus を使うときは claude-opus で起動し直すこと。
+claude-opus() {
+  CLAUDE_CODE_DISABLE_1M_CONTEXT=1 \
+  CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 \
+  CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65 \
+  command claude --model claude-opus-4-8 "$@"
+}
 
 # ─── Codex CLI: マルチアカウント切替 ───────────────────────────────
 # 主アカウントは既定の ~/.codex（env 不要）。もう一方は ~/.codex-work に置く。

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -106,8 +106,12 @@ alias -s md=mdv
 
 # Opus 4.8 用の品質プロファイル起動（1M 無効 + auto-compact を約 130k で早期発火）
 # 背景: dotfiles Issue #66（Opus の捏造・parse error は長 context + extended thinking で悪化する）
-# 注意: env はプロセス起動時にのみ読まれる。Fable セッション内の /model 切り替えでは適用されない。
-#       Opus を使うときは claude-opus で起動し直すこと。
+# 注意: env はプロセス起動時にのみ読まれ、セッション中の /model 切り替えでは compact 窓の
+#       指定は適用されない（auto-compact 閾値自体は現在モデルの窓に自動追従する。v2.1.215 実装確認）。
+#       - セッション中に Opus へ切り替えるときは必ず「Opus 4.8」（1M なし）を選ぶこと。
+#         「Opus 4.8 (1M context)」は [1m] 明示が env より優先されるため危険（1M + 遅い compact）。
+#       - フルプロファイル（1M 無効 + 約 130k で compact 発火）に切り替えたいときは、いったん
+#         閉じて claude-opus --resume（または claude-opus -c）で会話を引き継いで開き直す（実測確認済み）。
 claude-opus() {
   CLAUDE_CODE_DISABLE_1M_CONTEXT=1 \
   CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 \

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -104,19 +104,22 @@ function mdv() {
 # e.g. typing `./README.md` or `README.md` runs mdv on it
 alias -s md=mdv
 
-# Opus 4.8 用の品質プロファイル起動（1M 無効 + auto-compact を約 130k で早期発火）
+# Opus 用の品質プロファイル起動（1M 無効 + auto-compact を約 130k で早期発火）
 # 背景: dotfiles Issue #66（Opus の捏造・parse error は長 context + extended thinking で悪化する）
+# 使い分け: 既定は settings.json 側の設定に従う（このマシンは 1M 有効・compact 30%）。
+#           長い context で品質が落ちたときに、この関数で 200k 運用へ切り替える。
 # 注意: env はプロセス起動時にのみ読まれ、セッション中の /model 切り替えでは compact 窓の
 #       指定は適用されない（auto-compact 閾値自体は現在モデルの窓に自動追従する。v2.1.215 実装確認）。
-#       - セッション中に Opus へ切り替えるときは必ず「Opus 4.8」（1M なし）を選ぶこと。
-#         「Opus 4.8 (1M context)」は [1m] 明示が env より優先されるため危険（1M + 遅い compact）。
+#       - セッション中に Opus へ切り替えるときは必ず 1M なしの「Opus 5」を選ぶこと。
+#         「Opus 5 (1M context)」は [1m] 明示が env より優先されるため危険（1M + 遅い compact）。
 #       - フルプロファイル（1M 無効 + 約 130k で compact 発火）に切り替えたいときは、いったん
 #         閉じて claude-opus --resume（または claude-opus -c）で会話を引き継いで開き直す（実測確認済み）。
+#       - モデル世代が上がったら CLAUDE_OPUS_MODEL の既定値を更新する。
 claude-opus() {
   CLAUDE_CODE_DISABLE_1M_CONTEXT=1 \
   CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 \
   CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65 \
-  command claude --model claude-opus-4-8 "$@"
+  command claude --model "${CLAUDE_OPUS_MODEL:-claude-opus-5}" "$@"
 }
 
 # ─── Codex CLI: マルチアカウント切替 ───────────────────────────────

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -12,7 +12,7 @@
   {{- end }}
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "32000",
     {{- /*
       1M コンテキストの無効化（disable1m: "1"=無効 / "0"=明示的に有効）と
       auto-compact 窓（autoCompactWindow）は、data.claude.* を定義したマシンでのみ出力する。


### PR DESCRIPTION
## 概要

Opus の品質プロファイル起動と env 系設定の見直しをまとめて行う（dotfiles Issue #66 の一環）。背景は「Opus の捏造・parse error が長 context + extended thinking で悪化する」ため、Opus を使うときだけ 1M を無効化し auto-compact を早期発火させる。あわせて常時 high の effort alias を撤去し、出力トークン上限を引き下げる。

### 変更内容

- **`claude-opus` 起動ラッパーを追加（Closes #67）**: `dot_zshrc.tmpl` に Opus 用の起動関数を追加した。`CLAUDE_CODE_DISABLE_1M_CONTEXT=1` / `CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000` / `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65` を付与して `claude --model "${CLAUDE_OPUS_MODEL:-claude-opus-5}"` を起動する（約 130k で auto-compact 発火）。env はプロセス起動時のみ読まれるため、Fable セッション内の `/model` 切り替えでは適用されない旨をコメントに明記した。
- **常時 high effort alias を撤去（Refs #68）**: `alias claude='claude --effort high'` をコメントごと削除した。effort はハーネス既定（動的）に戻る。
- **`CLAUDE_CODE_MAX_OUTPUT_TOKENS` を引き下げ（Closes #71）**: `private_dot_claude/settings.json.tmpl` の env ブロックの値を `64000` から `32000` に変更した。Go template の変数構造は変更していない。

### スコープ外

- #68 の「モデル別 effort の実測」は運用フォローアップのため本 PR では対応しない。そのため #68 は Closes ではなく Refs で参照する。

## テスト計画

### 実施済み（本 PR 内で検証）

- `dot_zshrc.tmpl` には Go template 変数が無いことを確認し、そのまま `zsh -n` で構文チェックが通過することを確認した。
- `private_dot_claude/settings.json.tmpl` は Go template 変数を含むため、`chezmoi execute-template`（標準入力へファイル内容を渡す読み取り専用操作。`apply` / `diff` は未実行）でレンダリングし、出力 JSON が妥当（`python3 -m json.tool` 通過）かつ `CLAUDE_CODE_MAX_OUTPUT_TOKENS` が `32000` になることを確認した。
- `git diff` で意図した変更のみであることを確認した。
- **セッション中のモデル切り替えと resume の実挙動を実測で確認した**（`claude -p --output-format json` の `modelUsage` キーで観測）:
  - 1M の有効/無効はモデル ID の `[1m]` サフィックスで決まる。`[1m]` 明示は無効化 env より優先される
  - `claude-opus --resume <session-id>` 相当（`[1m]` なしモデル + env）で、1M 有効で開始した既存セッションを会話を引き継いだまま 1M 無効化できる
  - auto-compact 閾値は現在のモデルの窓に追従して再計算される（バイナリ v2.1.215 の実装で確認）。よってセッション中の切り替えは「Opus 5（1M なし）」を選べば安全で、危険なのは「Opus 5 (1M context)」を選んだ場合のみ（zshrc コメントに運用ルールとして明記）

### post-merge 検証（マージ後にメイン環境で実施）

1. `chezmoi diff` で `~/.zshrc` と `~/.claude/settings.json` の差分が意図どおりか確認する。
2. `chezmoi apply` を実行する。
3. 新しい zsh を起動し、`claude-opus` 関数が定義されていること（`type claude-opus`）、`claude` の alias が消えていること（`type claude` が関数/alias ではなく素の bin を指す）を確認する。
4. `claude-opus` で起動したセッションで `env | grep CLAUDE_` を確認し、`CLAUDE_CODE_DISABLE_1M_CONTEXT=1` / `CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000` / `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=65` が入っていること、`/model` 表示が Opus 5 であること、auto-compact 閾値が約 130k で発火することを確認する。

## レビュー対応の追記（2026-07-27）

起動関数が固定していたモデルが、現在使っている Opus の世代と合わなくなっていたため更新した。

- `--model claude-opus-4-8` を `--model "${CLAUDE_OPUS_MODEL:-claude-opus-5}"` に変更した。環境変数 `CLAUDE_OPUS_MODEL` で上書きでき、未設定なら Opus 5 を使う
- 関数の役割をコメントに明記した。ふだんの設定は `settings.json` 側が持ち（このマシンは 1M 有効・auto-compact 30%）、長い context で品質が落ちたときにこの関数で 200k 運用へ切り替える
- 本文中の「Opus 4.8」という記述を現行世代に合わせて書き換えた

`zsh -n` による構文チェックは通っている。`chezmoi apply` を伴う post-merge 検証の手順は変わらない。
