### PR TITLE
feat(claude): coderabbit-review-trigger スキルを追加

### DIFF
--- a/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
+++ b/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
@@ -1,0 +1,103 @@
+---
+description: >-
+  CodeRabbit のレビューを PR にトリガーし、トリガー後に「レビューが起動したか / rate limit で
+  制限中か / 結果が投稿されたか」を監視・判定するスキル。`@coderabbitai review` / `full review`
+  はコメントを投げても rate limit（Fair Usage Limits）で silent に skip されることがあり、
+  投げっぱなしだと起動したか分からない。しかも制限中でも「Full review finished」と併記されるため
+  完了と誤読しやすい。本スキルはトリガー → 応答コメントの監視 → 状態判定 →（制限中なら解除目安の
+  算出）まで行う。approve は扱わない（coderabbit-approve へ）。「CodeRabbit にレビューさせて」
+  「CodeRabbit をトリガー」「full review 依頼」「レビュー回して」「CodeRabbit 起動したか確認」
+  「rate limit 中か見て」「CodeRabbit の反応を監視」等の依頼時に使用。
+argument-hint: "[PR番号] [--mode full|incremental]"
+---
+
+# CodeRabbit Review Trigger + Startup Monitor
+
+CodeRabbit に**レビューをトリガー**し、その直後に **起動したか / 制限中か / 結果が出たか** を確認するための正本手順。トリガー系コマンド（`review` / `full review`）は投稿しても rate limit で無言のまま skip されることがあり、「投げたのに起動したか分からない」を防ぐのが本スキルの目的。
+
+## なぜトリガーだけでは不十分か
+
+CodeRabbit は Fair Usage Limits（adaptive limit）を持ち、短期間に多くのレビューを回すと制限される。制限中は次のように振る舞うため、**トリガーの投稿成功 ≠ レビュー起動**である。
+
+- 制限中に `@coderabbitai full review` を投げると、応答コメントに「**Full review finished**」と書かれつつ同じコメント内で「**You're currently rate limited … available in N minutes**」が併記される。「finished」だけ読むと完了と誤読するが、**実レビュー結果（walkthrough / actionable comments）は投稿されていない**。
+- そもそも受領時はまず 👀 リアクションだけ付き、本文コメントが遅れて出ることもある。
+
+したがって、トリガー後は必ず応答コメントを取得し、**rate limit 表現を最優先で判定**する必要がある。
+
+## coderabbit-approve との棲み分け
+
+| スキル | 役割 |
+|---|---|
+| **本スキル（coderabbit-review-trigger）** | レビューを**トリガー**し、**起動 / 制限中 / 結果投稿**を監視・判定する |
+| `coderabbit-approve` | 正式 GitHub APPROVED を取得しマージゲートを埋める（`@coderabbitai approve`・`request_changes_workflow` 依存） |
+
+本スキルは approve しない。レビュー結果が出て指摘対応が済んだあと、承認が要る場合は `coderabbit-approve` へ渡す。
+
+## 標準手順
+
+PR 番号を引数で受ける。owner/repo は未指定なら `gh repo view` から解決する。
+
+### Step 1: トリガー + 監視（1 コマンド）
+
+同梱スクリプトがトリガー投稿と応答監視をまとめて行う。
+
+```bash
+bash ~/.claude/skills/coderabbit-review-trigger/scripts/trigger-and-watch.sh <PR> \
+  [--repo owner/repo] [--mode full|incremental] [--poll 秒] [--max 回数]
+```
+
+- `--mode full`（既定）= 全体再レビュー（`@coderabbitai full review`）。`incremental` = 増分レビュー（`@coderabbitai review`）。
+- 既定は 30 秒間隔 × 8 回 = 最大約 4 分監視する。CodeRabbit の応答が遅いリポジトリでは `--max` を増やす。
+- **長時間 sleep はハーネスでブロックされることがある**。監視窓を長く取りたいときは、この呼び出し自体を**バックグラウンド実行**する（Bash の `run_in_background`）。
+
+スクリプトは最終行に `STATE=...` を出す。意味は次のとおり。
+
+| STATE | 意味 | 次アクション |
+|---|---|---|
+| `POSTED` | walkthrough / actionable comments 等の結果が投稿された | 指摘を確認。承認が要れば `coderabbit-approve` へ |
+| `REVIEWING` | レビュー実行中の応答を確認 | 少し置いて `--no-trigger` で再確認 |
+| `RATE_LIMITED` | 制限中。実レビューは未実施 | `RETRY_AFTER` の目安まで待って再トリガー（Step 2） |
+| `OTHER` | CodeRabbit 応答はあるが分類外 | 本文を目視確認 |
+| `NO_RESPONSE` | 監視窓内に新規応答なし | `--poll`/`--max` を増やすか、後刻 `--no-trigger` で確認 |
+
+### Step 2: rate limit 解除後の再トリガー
+
+`RATE_LIMITED` のとき、スクリプトは `RETRY_AFTER: 約 N 分後（目安 <UTC 時刻>）` を出す。**解除前に催促しても再び skip されるだけ**なので、目安時刻まで待ってから再実行する。
+
+```bash
+# 解除目安を過ぎたら、トリガーせず監視のみで実状態を確認 → まだ結果が無ければ再トリガー
+bash .../trigger-and-watch.sh <PR> --no-trigger        # 現状だけ確認
+bash .../trigger-and-watch.sh <PR> --mode full         # 再トリガー + 監視
+```
+
+待機を自動化するなら、解除目安まで空けて再実行する形をバックグラウンドに置く（`run_in_background` で「解除時刻付近に起動 → `--no-trigger` で確認 → 未完なら再トリガー」）。数十分規模の待機を前面で回さない。
+
+### Step 3: 状態確認だけしたいとき（トリガーしない）
+
+既にトリガー済みで「今どうなっているか」だけ見たい場合は `--no-trigger` を使う。無駄な再トリガーで rate limit を消費しない。
+
+```bash
+bash .../trigger-and-watch.sh <PR> --no-trigger
+```
+
+## 判定の要点（スクリプトの内部ロジック）
+
+- **rate limit を最優先で判定**する。「Full review finished」と rate limit が併記されるため、finished 語を先に見ると誤判定する。
+- 最新の CodeRabbit コメントは全ページを `--slurp` で束ねて `created_at` でソートして取る。**この gh では `--slurp` と `--jq` は併用できない**ため、`--slurp` の出力をパイプで jq に渡す。
+- コメント本文には制御文字が混じることがある。生テキストを別 jq に食わせると `U+0000-001F` で parse error になるため、`jq -c` で valid JSON 化してから `.body` を再取得する。
+- baseline（トリガー前の最新 CodeRabbit コメント時刻）より後の応答だけを「今回の応答」とみなし、古いコメントで誤判定しない。
+
+## アンチパターン
+
+- ❌ `@coderabbitai full review` を投げて完了扱いにする（rate limit で silent skip されうる。応答監視が必須）
+- ❌ 「Full review finished」だけ見て結果が出たと判断する（rate limit 併記時は結果未投稿）
+- ❌ rate limit 解除前に催促を繰り返す（再 skip されるだけ。目安時刻まで待つ）
+- ❌ 本スキルで approve まで期待する（approve は `coderabbit-approve`）
+- ❌ 数十分の解除待ちを前面 `sleep` で回す（ハーネスでブロックされうる。バックグラウンドに置く）
+
+## 関連
+
+- `coderabbit-approve` — 正式 APPROVED 取得・マージゲート充足（本スキルの後段）
+- `review-doc` / `peer-review` / `self-review` — レビュー本体の観点別スキル
+- メモリ `feedback_coderabbit_merge_workflow` — 本組織の CodeRabbit 運用（承認1件必須・rate limit は解除時刻を待つ）
+- 出典: [CodeRabbit Commands](https://docs.coderabbit.ai/guides/commands) / [Fair Usage Limits](https://docs.coderabbit.ai/management/plans#fair-usage-limits-policy)

--- a/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
+++ b/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
@@ -59,6 +59,7 @@ bash ~/.claude/skills/coderabbit-review-trigger/scripts/trigger-and-watch.sh <PR
 | `POSTED` | walkthrough / actionable comments 等の結果が投稿された | 指摘を確認。承認が要れば `coderabbit-approve` へ |
 | `REVIEWING` | レビュー実行中の応答を確認 | 少し置いて `--no-trigger` で再確認 |
 | `RATE_LIMITED` | 制限中。実レビューは未実施 | `RETRY_AFTER` の目安まで待って再トリガー（Step 2） |
+| `RATE_LIMIT_EXPIRED` | 制限通知は残っているが、解除目安を過ぎている | 再トリガーしてよい（Step 2） |
 | `OTHER` | CodeRabbit 応答はあるが分類外 | 本文を目視確認 |
 | `NO_RESPONSE` | 監視窓内に新規応答なし | `--poll`/`--max` を増やすか、後刻 `--no-trigger` で確認 |
 | `ERROR` | 引数、GitHub API、またはコマンドのエラー | エラーメッセージを確認してから再実行 |
@@ -72,6 +73,8 @@ bash ~/.claude/skills/coderabbit-review-trigger/scripts/trigger-and-watch.sh <PR
 bash .../trigger-and-watch.sh <PR> --no-trigger        # 現状だけ確認
 bash .../trigger-and-watch.sh <PR> --mode full         # 再トリガー + 監視
 ```
+
+`--no-trigger` が `RATE_LIMIT_EXPIRED` を返した場合は、解除目安を過ぎている。再トリガーしてよい。
 
 待機を自動化するなら、解除目安まで空けて再実行する形をバックグラウンドに置く（`run_in_background` で「解除時刻付近に起動 → `--no-trigger` で確認 → 未完なら再トリガー」）。数十分規模の待機を前面で回さない。
 
@@ -89,7 +92,9 @@ bash .../trigger-and-watch.sh <PR> --no-trigger
 - ポーリング中の取得失敗は、連続 3 回まで再試行する。3 回連続で失敗した場合は `ERROR` で終了する。
 - 最新の CodeRabbit コメントは全ページを `--slurp` で束ね、コメント ID でソートして取る。**この gh では `--slurp` と `--jq` は併用できない**ため、`--slurp` の出力をパイプで jq に渡す。
 - コメント本文には制御文字が混じることがある。生テキストを別 jq に食わせると `U+0000-001F` で parse error になるため、`jq -c` で valid JSON 化してから `.body` を再取得する。
-- baseline には、トリガー前の最新 CodeRabbit コメント ID を使う。baseline より大きい ID の応答だけを「今回の応答」とみなす。
+- baseline には、トリガー前の最新 CodeRabbit コメント ID を使う。baseline より大きい ID の応答だけを「今回の応答」とみなす。baseline はトリガーする経路でのみ取得する（`--no-trigger` では使わないため）。
+- 解除目安の表記は 2 通りある。`Your next included review will be available in 44 minutes.` と、`**Next review available in:** **59 minutes**` のように Markdown の強調が間に挟まる形である。どちらも拾えるよう、`available in` と数字の間に記号と空白を許容する正規表現を使う。
+- `--no-trigger` では、制限通知の投稿時刻と解除目安から**解除済みかどうか**を判定する。解除目安を過ぎていれば `RATE_LIMIT_EXPIRED` を返す。解除目安が本文に無い場合や時刻の変換に失敗した場合は、安全側に倒して `RATE_LIMITED` のままにする。
 
 ## アンチパターン
 

--- a/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
+++ b/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
@@ -2,10 +2,11 @@
 description: >-
   CodeRabbit のレビューを PR にトリガーし、トリガー後に「レビューが起動したか / rate limit で
   制限中か / 結果が投稿されたか」を監視・判定するスキル。`@coderabbitai review` / `full review`
-  はコメントを投げても rate limit（Fair Usage Limits）で silent に skip されることがあり、
-  投げっぱなしだと起動したか分からない。しかも制限中でも「Full review finished」と併記されるため
-  完了と誤読しやすい。本スキルはトリガー → 応答コメントの監視 → 状態判定 →（制限中なら解除目安の
-  算出）まで行う。approve は扱わない（coderabbit-approve へ）。「CodeRabbit にレビューさせて」
+  はコメントを投げても rate limit（Fair Usage Limits）で実レビューが実行されないことがある。
+  その場合も、CodeRabbit は制限を知らせるコメントを投稿する。制限中のコメントには
+  「Full review finished」が併記されることがあり、完了と誤読しやすい。本スキルはトリガー →
+  応答コメントの監視 → 状態判定 →（制限中なら解除目安の算出）まで行う。approve は扱わない
+  （coderabbit-approve へ）。「CodeRabbit にレビューさせて」
   「CodeRabbit をトリガー」「full review 依頼」「レビュー回して」「CodeRabbit 起動したか確認」
   「rate limit 中か見て」「CodeRabbit の反応を監視」等の依頼時に使用。
 argument-hint: "[PR番号] [--mode full|incremental]"
@@ -13,7 +14,7 @@ argument-hint: "[PR番号] [--mode full|incremental]"
 
 # CodeRabbit Review Trigger + Startup Monitor
 
-CodeRabbit に**レビューをトリガー**し、その直後に **起動したか / 制限中か / 結果が出たか** を確認するための正本手順。トリガー系コマンド（`review` / `full review`）は投稿しても rate limit で無言のまま skip されることがあり、「投げたのに起動したか分からない」を防ぐのが本スキルの目的。
+CodeRabbit に**レビューをトリガー**し、その直後に **起動したか / 制限中か / 結果が出たか** を確認するための正本手順。rate limit 中は、CodeRabbit が実レビューを実行しない。その場合も CodeRabbit は制限を知らせるコメントを投稿するので、本スキルはそのコメントを取得して状態を判定する。「投げたのに起動したか分からない」を防ぐのが目的である。
 
 ## なぜトリガーだけでは不十分か
 
@@ -51,6 +52,7 @@ bash ~/.claude/skills/coderabbit-review-trigger/scripts/trigger-and-watch.sh <PR
 - **長時間 sleep はハーネスでブロックされることがある**。監視窓を長く取りたいときは、この呼び出し自体を**バックグラウンド実行**する（Bash の `run_in_background`）。
 
 スクリプトは最終行に `STATE=...` を出す。意味は次のとおり。
+判定が完了した場合の終了コードは 0 である。実行エラーは 1、引数エラーは 2 で終了する。
 
 | STATE | 意味 | 次アクション |
 |---|---|---|
@@ -59,10 +61,11 @@ bash ~/.claude/skills/coderabbit-review-trigger/scripts/trigger-and-watch.sh <PR
 | `RATE_LIMITED` | 制限中。実レビューは未実施 | `RETRY_AFTER` の目安まで待って再トリガー（Step 2） |
 | `OTHER` | CodeRabbit 応答はあるが分類外 | 本文を目視確認 |
 | `NO_RESPONSE` | 監視窓内に新規応答なし | `--poll`/`--max` を増やすか、後刻 `--no-trigger` で確認 |
+| `ERROR` | 引数、GitHub API、またはコマンドのエラー | エラーメッセージを確認してから再実行 |
 
 ### Step 2: rate limit 解除後の再トリガー
 
-`RATE_LIMITED` のとき、スクリプトは `RETRY_AFTER: 約 N 分後（目安 <UTC 時刻>）` を出す。**解除前に催促しても再び skip されるだけ**なので、目安時刻まで待ってから再実行する。
+`RATE_LIMITED` のとき、スクリプトは `RETRY_AFTER: 約 N 分後（目安 <UTC 時刻>）` を出す。解除前に再トリガーしても、実レビューは実行されない。目安時刻まで待ってから再実行する。
 
 ```bash
 # 解除目安を過ぎたら、トリガーせず監視のみで実状態を確認 → まだ結果が無ければ再トリガー
@@ -83,15 +86,16 @@ bash .../trigger-and-watch.sh <PR> --no-trigger
 ## 判定の要点（スクリプトの内部ロジック）
 
 - **rate limit を最優先で判定**する。「Full review finished」と rate limit が併記されるため、finished 語を先に見ると誤判定する。
-- 最新の CodeRabbit コメントは全ページを `--slurp` で束ねて `created_at` でソートして取る。**この gh では `--slurp` と `--jq` は併用できない**ため、`--slurp` の出力をパイプで jq に渡す。
+- ポーリング中の取得失敗は、連続 3 回まで再試行する。3 回連続で失敗した場合は `ERROR` で終了する。
+- 最新の CodeRabbit コメントは全ページを `--slurp` で束ね、コメント ID でソートして取る。**この gh では `--slurp` と `--jq` は併用できない**ため、`--slurp` の出力をパイプで jq に渡す。
 - コメント本文には制御文字が混じることがある。生テキストを別 jq に食わせると `U+0000-001F` で parse error になるため、`jq -c` で valid JSON 化してから `.body` を再取得する。
-- baseline（トリガー前の最新 CodeRabbit コメント時刻）より後の応答だけを「今回の応答」とみなし、古いコメントで誤判定しない。
+- baseline には、トリガー前の最新 CodeRabbit コメント ID を使う。baseline より大きい ID の応答だけを「今回の応答」とみなす。
 
 ## アンチパターン
 
-- ❌ `@coderabbitai full review` を投げて完了扱いにする（rate limit で silent skip されうる。応答監視が必須）
+- ❌ `@coderabbitai full review` を投げて完了扱いにする（rate limit 中は実レビューが実行されない。制限を知らせるコメントの確認が必須）
 - ❌ 「Full review finished」だけ見て結果が出たと判断する（rate limit 併記時は結果未投稿）
-- ❌ rate limit 解除前に催促を繰り返す（再 skip されるだけ。目安時刻まで待つ）
+- ❌ rate limit 解除前に催促を繰り返す（実レビューは実行されない。目安時刻まで待つ）
 - ❌ 本スキルで approve まで期待する（approve は `coderabbit-approve`）
 - ❌ 数十分の解除待ちを前面 `sleep` で回す（ハーネスでブロックされうる。バックグラウンドに置く）
 

--- a/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
+++ b/private_dot_claude/skills/coderabbit-review-trigger/SKILL.md
@@ -2,11 +2,10 @@
 description: >-
   CodeRabbit のレビューを PR にトリガーし、トリガー後に「レビューが起動したか / rate limit で
   制限中か / 結果が投稿されたか」を監視・判定するスキル。`@coderabbitai review` / `full review`
-  はコメントを投げても rate limit（Fair Usage Limits）で実レビューが実行されないことがある。
-  その場合も、CodeRabbit は制限を知らせるコメントを投稿する。制限中のコメントには
-  「Full review finished」が併記されることがあり、完了と誤読しやすい。本スキルはトリガー →
-  応答コメントの監視 → 状態判定 →（制限中なら解除目安の算出）まで行う。approve は扱わない
-  （coderabbit-approve へ）。「CodeRabbit にレビューさせて」
+  はコメントを投げても rate limit（Fair Usage Limits）で silent に skip されることがあり、
+  投げっぱなしだと起動したか分からない。しかも制限中でも「Full review finished」と併記されるため
+  完了と誤読しやすい。本スキルはトリガー → 応答コメントの監視 → 状態判定 →（制限中なら解除目安の
+  算出）まで行う。approve は扱わない（coderabbit-approve へ）。「CodeRabbit にレビューさせて」
   「CodeRabbit をトリガー」「full review 依頼」「レビュー回して」「CodeRabbit 起動したか確認」
   「rate limit 中か見て」「CodeRabbit の反応を監視」等の依頼時に使用。
 argument-hint: "[PR番号] [--mode full|incremental]"
@@ -14,7 +13,7 @@ argument-hint: "[PR番号] [--mode full|incremental]"
 
 # CodeRabbit Review Trigger + Startup Monitor
 
-CodeRabbit に**レビューをトリガー**し、その直後に **起動したか / 制限中か / 結果が出たか** を確認するための正本手順。rate limit 中は、CodeRabbit が実レビューを実行しない。その場合も CodeRabbit は制限を知らせるコメントを投稿するので、本スキルはそのコメントを取得して状態を判定する。「投げたのに起動したか分からない」を防ぐのが目的である。
+CodeRabbit に**レビューをトリガー**し、その直後に **起動したか / 制限中か / 結果が出たか** を確認するための正本手順。トリガー系コマンド（`review` / `full review`）は投稿しても rate limit で無言のまま skip されることがあり、「投げたのに起動したか分からない」を防ぐのが本スキルの目的。
 
 ## なぜトリガーだけでは不十分か
 
@@ -52,29 +51,24 @@ bash ~/.claude/skills/coderabbit-review-trigger/scripts/trigger-and-watch.sh <PR
 - **長時間 sleep はハーネスでブロックされることがある**。監視窓を長く取りたいときは、この呼び出し自体を**バックグラウンド実行**する（Bash の `run_in_background`）。
 
 スクリプトは最終行に `STATE=...` を出す。意味は次のとおり。
-判定が完了した場合の終了コードは 0 である。実行エラーは 1、引数エラーは 2 で終了する。
 
 | STATE | 意味 | 次アクション |
 |---|---|---|
 | `POSTED` | walkthrough / actionable comments 等の結果が投稿された | 指摘を確認。承認が要れば `coderabbit-approve` へ |
 | `REVIEWING` | レビュー実行中の応答を確認 | 少し置いて `--no-trigger` で再確認 |
 | `RATE_LIMITED` | 制限中。実レビューは未実施 | `RETRY_AFTER` の目安まで待って再トリガー（Step 2） |
-| `RATE_LIMIT_EXPIRED` | 制限通知は残っているが、解除目安を過ぎている | 再トリガーしてよい（Step 2） |
 | `OTHER` | CodeRabbit 応答はあるが分類外 | 本文を目視確認 |
 | `NO_RESPONSE` | 監視窓内に新規応答なし | `--poll`/`--max` を増やすか、後刻 `--no-trigger` で確認 |
-| `ERROR` | 引数、GitHub API、またはコマンドのエラー | エラーメッセージを確認してから再実行 |
 
 ### Step 2: rate limit 解除後の再トリガー
 
-`RATE_LIMITED` のとき、スクリプトは `RETRY_AFTER: 約 N 分後（目安 <UTC 時刻>）` を出す。解除前に再トリガーしても、実レビューは実行されない。目安時刻まで待ってから再実行する。
+`RATE_LIMITED` のとき、スクリプトは `RETRY_AFTER: 約 N 分後（目安 <UTC 時刻>）` を出す。**解除前に催促しても再び skip されるだけ**なので、目安時刻まで待ってから再実行する。
 
 ```bash
 # 解除目安を過ぎたら、トリガーせず監視のみで実状態を確認 → まだ結果が無ければ再トリガー
 bash .../trigger-and-watch.sh <PR> --no-trigger        # 現状だけ確認
 bash .../trigger-and-watch.sh <PR> --mode full         # 再トリガー + 監視
 ```
-
-`--no-trigger` が `RATE_LIMIT_EXPIRED` を返した場合は、解除目安を過ぎている。再トリガーしてよい。
 
 待機を自動化するなら、解除目安まで空けて再実行する形をバックグラウンドに置く（`run_in_background` で「解除時刻付近に起動 → `--no-trigger` で確認 → 未完なら再トリガー」）。数十分規模の待機を前面で回さない。
 
@@ -89,18 +83,15 @@ bash .../trigger-and-watch.sh <PR> --no-trigger
 ## 判定の要点（スクリプトの内部ロジック）
 
 - **rate limit を最優先で判定**する。「Full review finished」と rate limit が併記されるため、finished 語を先に見ると誤判定する。
-- ポーリング中の取得失敗は、連続 3 回まで再試行する。3 回連続で失敗した場合は `ERROR` で終了する。
-- 最新の CodeRabbit コメントは全ページを `--slurp` で束ね、コメント ID でソートして取る。**この gh では `--slurp` と `--jq` は併用できない**ため、`--slurp` の出力をパイプで jq に渡す。
+- 最新の CodeRabbit コメントは全ページを `--slurp` で束ねて `created_at` でソートして取る。**この gh では `--slurp` と `--jq` は併用できない**ため、`--slurp` の出力をパイプで jq に渡す。
 - コメント本文には制御文字が混じることがある。生テキストを別 jq に食わせると `U+0000-001F` で parse error になるため、`jq -c` で valid JSON 化してから `.body` を再取得する。
-- baseline には、トリガー前の最新 CodeRabbit コメント ID を使う。baseline より大きい ID の応答だけを「今回の応答」とみなす。baseline はトリガーする経路でのみ取得する（`--no-trigger` では使わないため）。
-- 解除目安の表記は 2 通りある。`Your next included review will be available in 44 minutes.` と、`**Next review available in:** **59 minutes**` のように Markdown の強調が間に挟まる形である。どちらも拾えるよう、`available in` と数字の間に記号と空白を許容する正規表現を使う。
-- `--no-trigger` では、制限通知の投稿時刻と解除目安から**解除済みかどうか**を判定する。解除目安を過ぎていれば `RATE_LIMIT_EXPIRED` を返す。解除目安が本文に無い場合や時刻の変換に失敗した場合は、安全側に倒して `RATE_LIMITED` のままにする。
+- baseline（トリガー前の最新 CodeRabbit コメント時刻）より後の応答だけを「今回の応答」とみなし、古いコメントで誤判定しない。
 
 ## アンチパターン
 
-- ❌ `@coderabbitai full review` を投げて完了扱いにする（rate limit 中は実レビューが実行されない。制限を知らせるコメントの確認が必須）
+- ❌ `@coderabbitai full review` を投げて完了扱いにする（rate limit で silent skip されうる。応答監視が必須）
 - ❌ 「Full review finished」だけ見て結果が出たと判断する（rate limit 併記時は結果未投稿）
-- ❌ rate limit 解除前に催促を繰り返す（実レビューは実行されない。目安時刻まで待つ）
+- ❌ rate limit 解除前に催促を繰り返す（再 skip されるだけ。目安時刻まで待つ）
 - ❌ 本スキルで approve まで期待する（approve は `coderabbit-approve`）
 - ❌ 数十分の解除待ちを前面 `sleep` で回す（ハーネスでブロックされうる。バックグラウンドに置く）
 

--- a/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
+++ b/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# CodeRabbit review trigger + startup monitor.
+#
+# CodeRabbit へレビューをトリガーし、その後の応答コメントを poll して
+# 「起動した / rate limit で制限中 / 結果投稿済み / 応答なし」を判定する。
+# rate limit の場合は "available in N minutes/hours" をパースし解除目安を出す。
+# approve は本スクリプトの範囲外（coderabbit-approve スキルへ）。
+#
+# Usage:
+#   trigger-and-watch.sh <PR> [--repo owner/repo] [--mode full|incremental]
+#                        [--poll SECONDS] [--max COUNT] [--no-trigger]
+#
+# Options:
+#   --repo        owner/repo（省略時は `gh repo view` から解決）
+#   --mode        full=全体再レビュー(既定) / incremental=増分レビュー
+#   --poll        poll 間隔秒（既定 30）
+#   --max         poll 最大回数（既定 8。既定で最大 4 分監視）
+#   --no-trigger  トリガーせず監視のみ（既にトリガー済みの状態確認に使う）
+#
+# Exit: 常に 0。判定結果は最終行の STATE=... で返す。
+#   STATE=POSTED        レビュー結果（walkthrough / actionable comments 等）が投稿された
+#   STATE=REVIEWING     レビュー実行中の応答を確認
+#   STATE=RATE_LIMITED  制限中。RETRY_AFTER 行に解除目安
+#   STATE=OTHER         CodeRabbit 応答はあるが分類外（本文を確認）
+#   STATE=NO_RESPONSE   監視窓内に新規応答なし（未起動 or 遅延）
+set -uo pipefail
+
+PR=""; MODE="full"; REPO=""; POLL=30; MAX=8; DO_TRIGGER=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="${2:-}"; shift 2;;
+    --mode) MODE="${2:-}"; shift 2;;
+    --poll) POLL="${2:-}"; shift 2;;
+    --max) MAX="${2:-}"; shift 2;;
+    --no-trigger) DO_TRIGGER=0; shift;;
+    -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    -*) echo "ERROR: unknown option $1" >&2; exit 2;;
+    *) PR="$1"; shift;;
+  esac
+done
+
+[ -n "$PR" ] || { echo "ERROR: PR number required" >&2; exit 2; }
+[ -n "$REPO" ] || REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+CR="coderabbitai[bot]"
+API="repos/$REPO/issues/$PR/comments"
+
+# 全ページを 1 配列に束ねて最新の CodeRabbit コメントを取る。
+# 注意: この gh では --slurp と --jq は併用不可。--slurp の出力をパイプで jq に渡す。
+# jq -c で valid JSON を返すので、呼び出し側で .body を再パースしても制御文字で壊れない
+# （body を生テキストで取り出して別 jq に食わせると U+0000-001F で parse error になる）。
+fetch_latest() {
+  gh api --paginate --slurp "$API" 2>/dev/null \
+    | jq -c 'add | map(select(.user.login=="coderabbitai[bot]")) | sort_by(.created_at) | last // empty' 2>/dev/null
+}
+
+# baseline: トリガー前の最新 CodeRabbit コメント時刻。これより後の応答を「トリガー後の応答」とみなす。
+baseline=$(fetch_latest | jq -r '.created_at // ""' 2>/dev/null || echo "")
+
+if [ "$DO_TRIGGER" -eq 1 ]; then
+  case "$MODE" in
+    full) CMD="@coderabbitai full review";;
+    incremental|inc) CMD="@coderabbitai review";;
+    *) echo "ERROR: --mode は full|incremental" >&2; exit 2;;
+  esac
+  gh pr comment "$PR" --repo "$REPO" --body "$CMD" >/dev/null \
+    && echo "TRIGGERED mode=$MODE pr=#$PR repo=$REPO cmd=\"$CMD\""
+fi
+
+classify() {
+  local body="$1"
+  if printf '%s' "$body" | grep -qiE 'rate limit|Review limit reached|available in [0-9]+ (minute|hour)'; then
+    echo "RATE_LIMITED"
+  elif printf '%s' "$body" | grep -qiE 'Actionable comments posted|Walkthrough|Full review finished|summarize by coderabbit'; then
+    echo "POSTED"
+  elif printf '%s' "$body" | grep -qiE 'currently reviewing|review in progress|Reviewing your'; then
+    echo "REVIEWING"
+  else
+    echo "OTHER"
+  fi
+}
+
+report_rate_limit() {
+  local body="$1"
+  local phrase num unit mins eta
+  phrase=$(printf '%s' "$body" | grep -oiE 'available in [0-9]+ (minutes?|hours?)' | head -1 || true)
+  echo "RATE_LIMIT_DETAIL: ${phrase:-（解除時刻の明記なし。本文を確認）}"
+  num=$(printf '%s' "$phrase" | grep -oE '[0-9]+' | head -1 || true)
+  unit=$(printf '%s' "$phrase" | grep -oiE 'minute|hour' | head -1 || true)
+  [ -n "$num" ] || return 0
+  case "$unit" in hour*) mins=$((num*60));; *) mins=$num;; esac
+  # BSD date(macOS) → GNU date の順で解除目安時刻を算出（best-effort）
+  eta=$(date -u -v+"${mins}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -d "+${mins} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?")
+  echo "RETRY_AFTER: 約 ${mins} 分後（目安 ${eta}）。解除前の再トリガーは再び skip されるだけなので待つこと。"
+}
+
+# --no-trigger: baseline 比較や poll をせず、現在の最新コメントをそのまま分類して即返す
+# （新規応答を待つ意味がないため。既にトリガー済みの「今どうなっているか」確認用）
+if [ "$DO_TRIGGER" -eq 0 ]; then
+  latest=$(fetch_latest)
+  if [ -z "$latest" ]; then
+    echo "STATE=NO_RESPONSE  (CodeRabbit のコメントがまだ 1 件もない)"
+    exit 0
+  fi
+  t=$(printf '%s' "$latest" | jq -r '.created_at')
+  body=$(printf '%s' "$latest" | jq -r '.body')
+  state=$(classify "$body")
+  echo "STATE=$state  at=$t  (--no-trigger 現状確認)"
+  [ "$state" = "RATE_LIMITED" ] && report_rate_limit "$body"
+  echo "--- CodeRabbit 応答（先頭 15 行） ---"
+  printf '%s\n' "$body" | head -15
+  exit 0
+fi
+
+i=0
+while [ "$i" -lt "$MAX" ]; do
+  sleep "$POLL"; i=$((i+1))
+  latest=$(fetch_latest)
+  [ -n "$latest" ] || continue
+  t=$(printf '%s' "$latest" | jq -r '.created_at')
+  newer=0
+  if [ -z "$baseline" ]; then newer=1
+  elif [[ "$t" > "$baseline" ]]; then newer=1
+  fi
+  [ "$newer" -eq 1 ] || continue
+  body=$(printf '%s' "$latest" | jq -r '.body')
+  state=$(classify "$body")
+  echo "STATE=$state  at=$t  (poll $i/$MAX)"
+  [ "$state" = "RATE_LIMITED" ] && report_rate_limit "$body"
+  echo "--- CodeRabbit 応答（先頭 15 行） ---"
+  printf '%s\n' "$body" | head -15
+  exit 0
+done
+
+echo "STATE=NO_RESPONSE  (${MAX}×${POLL}s 監視で baseline 以降の新規 CodeRabbit 応答なし)"
+echo "HINT: CodeRabbit は受領時にまず 👀 リアクションのみ付けることがある。--poll/--max を増やすか、少し置いて --no-trigger で再確認する。"
+exit 0

--- a/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
+++ b/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
@@ -22,6 +22,8 @@
 #   STATE=POSTED        レビュー結果（walkthrough / actionable comments 等）が投稿された
 #   STATE=REVIEWING     レビュー実行中の応答を確認
 #   STATE=RATE_LIMITED  制限中。RETRY_AFTER 行に解除目安
+#   STATE=RATE_LIMIT_EXPIRED
+#                       制限通知は残っているが解除目安を超過。再トリガー可能
 #   STATE=OTHER         CodeRabbit 応答はあるが分類外（本文を確認）
 #   STATE=NO_RESPONSE   監視窓内に新規応答なし（未起動 or 遅延）
 #   STATE=ERROR         引数、GitHub API、またはコマンドのエラー
@@ -93,6 +95,12 @@ CR="${CODERABBIT_BOT:-coderabbitai[bot]}"
 API="repos/$REPO/issues/$PR/comments"
 MAX_FETCH_FAILURES=3
 
+# 解除目安を拾う正規表現。CodeRabbit の表記は 2 通りあり、両方に対応する。
+#   1) "Your next included review will be available in 44 minutes."
+#   2) "**Next review available in:** **59 minutes**"（Markdown の強調が間に挟まる）
+# そのため "available in" と数字の間に、記号と空白を数文字まで許容する。
+ETA_RE='available in[^0-9]{0,12}[0-9]+ *\**(minutes?|hours?)'
+
 # 全ページを 1 配列に束ねて最新の CodeRabbit コメントを取る。
 # 注意: この gh では --slurp と --jq は併用不可。--slurp の出力をパイプで jq に渡す。
 # jq -c で valid JSON を返すので、呼び出し側で .body を再パースしても制御文字で壊れない
@@ -103,17 +111,17 @@ fetch_latest() {
       '(add // []) | map(select(.user.login==$bot)) | sort_by(.id) | last // empty'
 }
 
-# baseline: トリガー前の最新 CodeRabbit コメント ID。
-# これより大きい ID の応答を「トリガー後の応答」とみなす。
-baseline_json=$(fetch_latest) || die "failed to fetch the baseline CodeRabbit comment"
-if [ -z "$baseline_json" ]; then
-  baseline=0
-else
-  baseline=$(printf '%s' "$baseline_json" | jq -r '.id') \
-    || die "failed to parse the baseline CodeRabbit comment"
-fi
-
 if [ "$DO_TRIGGER" -eq 1 ]; then
+  # baseline: トリガー前の最新 CodeRabbit コメント ID。
+  # これより大きい ID の応答を「トリガー後の応答」とみなす。
+  baseline_json=$(fetch_latest) || die "failed to fetch the baseline CodeRabbit comment"
+  if [ -z "$baseline_json" ]; then
+    baseline=0
+  else
+    baseline=$(printf '%s' "$baseline_json" | jq -r '.id') \
+      || die "failed to parse the baseline CodeRabbit comment"
+  fi
+
   case "$MODE" in
     full) CMD="@coderabbitai full review";;
     incremental|inc) CMD="@coderabbitai review";;
@@ -126,7 +134,7 @@ fi
 
 classify() {
   local body="$1"
-  if printf '%s' "$body" | grep -qiE 'rate limit|Review limit reached|available in [0-9]+ (minute|hour)'; then
+  if printf '%s' "$body" | grep -qiE "rate limit|Review limit reached|$ETA_RE"; then
     echo "RATE_LIMITED"
   elif printf '%s' "$body" | grep -qiE 'Actionable comments posted|Walkthrough|Full review finished|summarize by coderabbit'; then
     echo "POSTED"
@@ -140,7 +148,7 @@ classify() {
 report_rate_limit() {
   local body="$1"
   local phrase num unit mins eta
-  phrase=$(printf '%s' "$body" | grep -oiE 'available in [0-9]+ (minutes?|hours?)' | head -1 || true)
+  phrase=$(printf '%s' "$body" | grep -oiE "$ETA_RE" | head -1 || true)
   echo "RATE_LIMIT_DETAIL: ${phrase:-（解除時刻の明記なし。本文を確認）}"
   num=$(printf '%s' "$phrase" | grep -oE '[0-9]+' | head -1 || true)
   unit=$(printf '%s' "$phrase" | grep -oiE 'minute|hour' | head -1 || true)
@@ -150,6 +158,31 @@ report_rate_limit() {
   eta=$(date -u -v+"${mins}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
         || date -u -d "+${mins} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?")
   echo "RETRY_AFTER: 約 ${mins} 分後（目安 ${eta}）。解除前に再トリガーしても実レビューは実行されないため、解除まで待つこと。"
+}
+
+rate_limit_has_expired() {
+  local body="$1"
+  local created_at="$2"
+  local phrase num unit mins created_epoch available_epoch now_epoch available_at
+  phrase=$(printf '%s' "$body" | grep -oiE "$ETA_RE" | head -1 || true)
+  num=$(printf '%s' "$phrase" | grep -oE '[0-9]+' | head -1 || true)
+  unit=$(printf '%s' "$phrase" | grep -oiE 'minute|hour' | head -1 || true)
+  [ -n "$num" ] || return 1
+  case "$unit" in hour*) mins=$((num*60));; *) mins=$num;; esac
+
+  # BSD date(macOS) → GNU date の順で投稿時刻を epoch 秒へ変換する（best-effort）。
+  created_epoch=$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$created_at" +%s 2>/dev/null \
+    || date -u -d "$created_at" +%s 2>/dev/null) || return 1
+  available_epoch=$((created_epoch + mins*60))
+  now_epoch=$(date -u +%s 2>/dev/null) || return 1
+  [ "$now_epoch" -ge "$available_epoch" ] || return 1
+
+  # BSD date(macOS) → GNU date の順で解除目安を UTC の ISO 8601 に戻す。
+  available_at=$(date -u -r "$available_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$available_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || echo "?")
+  echo "RATE_LIMIT_EXPIRED_DETAIL: posted_at=$created_at estimated_available_at=$available_at"
+  return 0
 }
 
 # --no-trigger: baseline 比較や poll をせず、現在の最新コメントをそのまま分類して即返す
@@ -167,6 +200,9 @@ if [ "$DO_TRIGGER" -eq 0 ]; then
     || die "failed to parse the latest CodeRabbit comment body"
   state=$(classify "$body")
   echo "OBSERVED: at=$t (--no-trigger 現状確認)"
+  if [ "$state" = "RATE_LIMITED" ] && rate_limit_has_expired "$body" "$t"; then
+    state="RATE_LIMIT_EXPIRED"
+  fi
   [ "$state" = "RATE_LIMITED" ] && report_rate_limit "$body"
   echo "--- CodeRabbit 応答（先頭 15 行） ---"
   printf '%s\n' "$body" | head -15

--- a/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
+++ b/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
@@ -17,54 +17,111 @@
 #   --max         poll 最大回数（既定 8。既定で最大 4 分監視）
 #   --no-trigger  トリガーせず監視のみ（既にトリガー済みの状態確認に使う）
 #
-# Exit: 常に 0。判定結果は最終行の STATE=... で返す。
+# Exit: 判定完了時は 0、実行エラー時は 1、引数エラー時は 2。
+# 判定結果は最終行の STATE=... で返す。
 #   STATE=POSTED        レビュー結果（walkthrough / actionable comments 等）が投稿された
 #   STATE=REVIEWING     レビュー実行中の応答を確認
 #   STATE=RATE_LIMITED  制限中。RETRY_AFTER 行に解除目安
 #   STATE=OTHER         CodeRabbit 応答はあるが分類外（本文を確認）
 #   STATE=NO_RESPONSE   監視窓内に新規応答なし（未起動 or 遅延）
+#   STATE=ERROR         引数、GitHub API、またはコマンドのエラー
 set -uo pipefail
 
 PR=""; MODE="full"; REPO=""; POLL=30; MAX=8; DO_TRIGGER=1
+
+die() {
+  local message="$1"
+  local code="${2:-1}"
+  echo "ERROR: $message" >&2
+  echo "STATE=ERROR"
+  exit "$code"
+}
+
+require_value() {
+  [ "$#" -ge 2 ] || die "$1 requires a value" 2
+  [ -n "$2" ] || die "$1 requires a value" 2
+  case "$2" in
+    --*) die "$1 requires a value" 2;;
+  esac
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo) REPO="${2:-}"; shift 2;;
-    --mode) MODE="${2:-}"; shift 2;;
-    --poll) POLL="${2:-}"; shift 2;;
-    --max) MAX="${2:-}"; shift 2;;
+    --repo) require_value "$@"; REPO="$2"; shift 2;;
+    --mode) require_value "$@"; MODE="$2"; shift 2;;
+    --poll) require_value "$@"; POLL="$2"; shift 2;;
+    --max) require_value "$@"; MAX="$2"; shift 2;;
     --no-trigger) DO_TRIGGER=0; shift;;
-    -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
-    -*) echo "ERROR: unknown option $1" >&2; exit 2;;
+    -h|--help)
+      sed -n '2,/^set -uo pipefail$/p' "$0" \
+        | grep -E '^#( |$)' \
+        | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*) die "unknown option $1" 2;;
     *) PR="$1"; shift;;
   esac
 done
 
-[ -n "$PR" ] || { echo "ERROR: PR number required" >&2; exit 2; }
-[ -n "$REPO" ] || REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+case "$PR" in
+  ''|*[!0-9]*) die "PR number must be an integer greater than or equal to 1" 2;;
+esac
+[ "$PR" -ge 1 ] || die "PR number must be an integer greater than or equal to 1" 2
 
-CR="coderabbitai[bot]"
+case "$POLL" in
+  ''|*[!0-9]*) die "--poll must be an integer greater than or equal to 1" 2;;
+esac
+[ "$POLL" -ge 1 ] || die "--poll must be an integer greater than or equal to 1" 2
+
+case "$MAX" in
+  ''|*[!0-9]*) die "--max must be an integer greater than or equal to 1" 2;;
+esac
+[ "$MAX" -ge 1 ] || die "--max must be an integer greater than or equal to 1" 2
+
+case "$MODE" in
+  full|incremental|inc) ;;
+  *) die "--mode は full|incremental" 2;;
+esac
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner) \
+    || die "repository resolution failed"
+  [ -n "$REPO" ] || die "repository resolution returned an empty value"
+fi
+
+CR="${CODERABBIT_BOT:-coderabbitai[bot]}"
 API="repos/$REPO/issues/$PR/comments"
+MAX_FETCH_FAILURES=3
 
 # 全ページを 1 配列に束ねて最新の CodeRabbit コメントを取る。
 # 注意: この gh では --slurp と --jq は併用不可。--slurp の出力をパイプで jq に渡す。
 # jq -c で valid JSON を返すので、呼び出し側で .body を再パースしても制御文字で壊れない
 # （body を生テキストで取り出して別 jq に食わせると U+0000-001F で parse error になる）。
 fetch_latest() {
-  gh api --paginate --slurp "$API" 2>/dev/null \
-    | jq -c 'add | map(select(.user.login=="coderabbitai[bot]")) | sort_by(.created_at) | last // empty' 2>/dev/null
+  gh api --paginate --slurp "$API" \
+    | jq -c --arg bot "$CR" \
+      '(add // []) | map(select(.user.login==$bot)) | sort_by(.id) | last // empty'
 }
 
-# baseline: トリガー前の最新 CodeRabbit コメント時刻。これより後の応答を「トリガー後の応答」とみなす。
-baseline=$(fetch_latest | jq -r '.created_at // ""' 2>/dev/null || echo "")
+# baseline: トリガー前の最新 CodeRabbit コメント ID。
+# これより大きい ID の応答を「トリガー後の応答」とみなす。
+baseline_json=$(fetch_latest) || die "failed to fetch the baseline CodeRabbit comment"
+if [ -z "$baseline_json" ]; then
+  baseline=0
+else
+  baseline=$(printf '%s' "$baseline_json" | jq -r '.id') \
+    || die "failed to parse the baseline CodeRabbit comment"
+fi
 
 if [ "$DO_TRIGGER" -eq 1 ]; then
   case "$MODE" in
     full) CMD="@coderabbitai full review";;
     incremental|inc) CMD="@coderabbitai review";;
-    *) echo "ERROR: --mode は full|incremental" >&2; exit 2;;
   esac
-  gh pr comment "$PR" --repo "$REPO" --body "$CMD" >/dev/null \
-    && echo "TRIGGERED mode=$MODE pr=#$PR repo=$REPO cmd=\"$CMD\""
+  if ! gh pr comment "$PR" --repo "$REPO" --body "$CMD" >/dev/null; then
+    die "failed to post the CodeRabbit review trigger"
+  fi
+  echo "TRIGGERED mode=$MODE pr=#$PR repo=$REPO cmd=\"$CMD\""
 fi
 
 classify() {
@@ -73,7 +130,7 @@ classify() {
     echo "RATE_LIMITED"
   elif printf '%s' "$body" | grep -qiE 'Actionable comments posted|Walkthrough|Full review finished|summarize by coderabbit'; then
     echo "POSTED"
-  elif printf '%s' "$body" | grep -qiE 'currently reviewing|review in progress|Reviewing your'; then
+  elif printf '%s' "$body" | grep -qiE 'currently reviewing|review in progress|Reviewing your|Review triggered|Full review triggered'; then
     echo "REVIEWING"
   else
     echo "OTHER"
@@ -92,47 +149,83 @@ report_rate_limit() {
   # BSD date(macOS) → GNU date の順で解除目安時刻を算出（best-effort）
   eta=$(date -u -v+"${mins}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
         || date -u -d "+${mins} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?")
-  echo "RETRY_AFTER: 約 ${mins} 分後（目安 ${eta}）。解除前の再トリガーは再び skip されるだけなので待つこと。"
+  echo "RETRY_AFTER: 約 ${mins} 分後（目安 ${eta}）。解除前に再トリガーしても実レビューは実行されないため、解除まで待つこと。"
 }
 
 # --no-trigger: baseline 比較や poll をせず、現在の最新コメントをそのまま分類して即返す
 # （新規応答を待つ意味がないため。既にトリガー済みの「今どうなっているか」確認用）
 if [ "$DO_TRIGGER" -eq 0 ]; then
-  latest=$(fetch_latest)
+  latest=$(fetch_latest) || die "failed to fetch the latest CodeRabbit comment"
   if [ -z "$latest" ]; then
-    echo "STATE=NO_RESPONSE  (CodeRabbit のコメントがまだ 1 件もない)"
+    echo "DETAIL: CodeRabbit のコメントがまだ 1 件もない"
+    echo "STATE=NO_RESPONSE"
     exit 0
   fi
-  t=$(printf '%s' "$latest" | jq -r '.created_at')
-  body=$(printf '%s' "$latest" | jq -r '.body')
+  t=$(printf '%s' "$latest" | jq -r '.created_at') \
+    || die "failed to parse the latest CodeRabbit comment timestamp"
+  body=$(printf '%s' "$latest" | jq -r '.body') \
+    || die "failed to parse the latest CodeRabbit comment body"
   state=$(classify "$body")
-  echo "STATE=$state  at=$t  (--no-trigger 現状確認)"
+  echo "OBSERVED: at=$t (--no-trigger 現状確認)"
   [ "$state" = "RATE_LIMITED" ] && report_rate_limit "$body"
   echo "--- CodeRabbit 応答（先頭 15 行） ---"
   printf '%s\n' "$body" | head -15
+  echo "STATE=$state"
   exit 0
 fi
 
 i=0
+fetch_failures=0
+last_state=""
+last_time=""
+last_body=""
 while [ "$i" -lt "$MAX" ]; do
   sleep "$POLL"; i=$((i+1))
-  latest=$(fetch_latest)
-  [ -n "$latest" ] || continue
-  t=$(printf '%s' "$latest" | jq -r '.created_at')
-  newer=0
-  if [ -z "$baseline" ]; then newer=1
-  elif [[ "$t" > "$baseline" ]]; then newer=1
+  if ! latest=$(fetch_latest); then
+    fetch_failures=$((fetch_failures+1))
+    echo "WARN: CodeRabbit コメントの取得に失敗しました (${fetch_failures}/${MAX_FETCH_FAILURES})" >&2
+    if [ "$fetch_failures" -ge "$MAX_FETCH_FAILURES" ]; then
+      die "failed to fetch CodeRabbit comments ${MAX_FETCH_FAILURES} consecutive times"
+    fi
+    continue
   fi
-  [ "$newer" -eq 1 ] || continue
-  body=$(printf '%s' "$latest" | jq -r '.body')
+  fetch_failures=0
+  [ -n "$latest" ] || continue
+  comment_id=$(printf '%s' "$latest" | jq -r '.id') \
+    || die "failed to parse the latest CodeRabbit comment ID"
+  [ "$comment_id" -gt "$baseline" ] || continue
+  t=$(printf '%s' "$latest" | jq -r '.created_at') \
+    || die "failed to parse the latest CodeRabbit comment timestamp"
+  body=$(printf '%s' "$latest" | jq -r '.body') \
+    || die "failed to parse the latest CodeRabbit comment body"
   state=$(classify "$body")
-  echo "STATE=$state  at=$t  (poll $i/$MAX)"
+  if [ "$state" = "REVIEWING" ]; then
+    last_state="$state"
+    last_time="$t"
+    last_body="$body"
+    continue
+  fi
+  echo "OBSERVED: at=$t (poll $i/$MAX)"
   [ "$state" = "RATE_LIMITED" ] && report_rate_limit "$body"
   echo "--- CodeRabbit 応答（先頭 15 行） ---"
   printf '%s\n' "$body" | head -15
+  echo "STATE=$state"
   exit 0
 done
 
-echo "STATE=NO_RESPONSE  (${MAX}×${POLL}s 監視で baseline 以降の新規 CodeRabbit 応答なし)"
+if [ "$fetch_failures" -gt 0 ]; then
+  die "monitoring ended after ${fetch_failures} consecutive fetch failure(s)"
+fi
+
+if [ "$last_state" = "REVIEWING" ]; then
+  echo "OBSERVED: at=$last_time (監視窓の終了時点でレビュー実行中)"
+  echo "--- CodeRabbit 応答（先頭 15 行） ---"
+  printf '%s\n' "$last_body" | head -15
+  echo "STATE=REVIEWING"
+  exit 0
+fi
+
+echo "DETAIL: ${MAX}×${POLL}s の監視で baseline 以降の新規 CodeRabbit 応答なし"
 echo "HINT: CodeRabbit は受領時にまず 👀 リアクションのみ付けることがある。--poll/--max を増やすか、少し置いて --no-trigger で再確認する。"
+echo "STATE=NO_RESPONSE"
 exit 0

--- a/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
+++ b/private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh
@@ -17,128 +17,63 @@
 #   --max         poll 最大回数（既定 8。既定で最大 4 分監視）
 #   --no-trigger  トリガーせず監視のみ（既にトリガー済みの状態確認に使う）
 #
-# Exit: 判定完了時は 0、実行エラー時は 1、引数エラー時は 2。
-# 判定結果は最終行の STATE=... で返す。
+# Exit: 常に 0。判定結果は最終行の STATE=... で返す。
 #   STATE=POSTED        レビュー結果（walkthrough / actionable comments 等）が投稿された
 #   STATE=REVIEWING     レビュー実行中の応答を確認
 #   STATE=RATE_LIMITED  制限中。RETRY_AFTER 行に解除目安
-#   STATE=RATE_LIMIT_EXPIRED
-#                       制限通知は残っているが解除目安を超過。再トリガー可能
 #   STATE=OTHER         CodeRabbit 応答はあるが分類外（本文を確認）
 #   STATE=NO_RESPONSE   監視窓内に新規応答なし（未起動 or 遅延）
-#   STATE=ERROR         引数、GitHub API、またはコマンドのエラー
 set -uo pipefail
 
 PR=""; MODE="full"; REPO=""; POLL=30; MAX=8; DO_TRIGGER=1
-
-die() {
-  local message="$1"
-  local code="${2:-1}"
-  echo "ERROR: $message" >&2
-  echo "STATE=ERROR"
-  exit "$code"
-}
-
-require_value() {
-  [ "$#" -ge 2 ] || die "$1 requires a value" 2
-  [ -n "$2" ] || die "$1 requires a value" 2
-  case "$2" in
-    --*) die "$1 requires a value" 2;;
-  esac
-}
-
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo) require_value "$@"; REPO="$2"; shift 2;;
-    --mode) require_value "$@"; MODE="$2"; shift 2;;
-    --poll) require_value "$@"; POLL="$2"; shift 2;;
-    --max) require_value "$@"; MAX="$2"; shift 2;;
+    --repo) REPO="${2:-}"; shift 2;;
+    --mode) MODE="${2:-}"; shift 2;;
+    --poll) POLL="${2:-}"; shift 2;;
+    --max) MAX="${2:-}"; shift 2;;
     --no-trigger) DO_TRIGGER=0; shift;;
-    -h|--help)
-      sed -n '2,/^set -uo pipefail$/p' "$0" \
-        | grep -E '^#( |$)' \
-        | sed 's/^# \{0,1\}//'
-      exit 0
-      ;;
-    -*) die "unknown option $1" 2;;
+    -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    -*) echo "ERROR: unknown option $1" >&2; exit 2;;
     *) PR="$1"; shift;;
   esac
 done
 
-case "$PR" in
-  ''|*[!0-9]*) die "PR number must be an integer greater than or equal to 1" 2;;
-esac
-[ "$PR" -ge 1 ] || die "PR number must be an integer greater than or equal to 1" 2
+[ -n "$PR" ] || { echo "ERROR: PR number required" >&2; exit 2; }
+[ -n "$REPO" ] || REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 
-case "$POLL" in
-  ''|*[!0-9]*) die "--poll must be an integer greater than or equal to 1" 2;;
-esac
-[ "$POLL" -ge 1 ] || die "--poll must be an integer greater than or equal to 1" 2
-
-case "$MAX" in
-  ''|*[!0-9]*) die "--max must be an integer greater than or equal to 1" 2;;
-esac
-[ "$MAX" -ge 1 ] || die "--max must be an integer greater than or equal to 1" 2
-
-case "$MODE" in
-  full|incremental|inc) ;;
-  *) die "--mode は full|incremental" 2;;
-esac
-
-if [ -z "$REPO" ]; then
-  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner) \
-    || die "repository resolution failed"
-  [ -n "$REPO" ] || die "repository resolution returned an empty value"
-fi
-
-CR="${CODERABBIT_BOT:-coderabbitai[bot]}"
+CR="coderabbitai[bot]"
 API="repos/$REPO/issues/$PR/comments"
-MAX_FETCH_FAILURES=3
-
-# 解除目安を拾う正規表現。CodeRabbit の表記は 2 通りあり、両方に対応する。
-#   1) "Your next included review will be available in 44 minutes."
-#   2) "**Next review available in:** **59 minutes**"（Markdown の強調が間に挟まる）
-# そのため "available in" と数字の間に、記号と空白を数文字まで許容する。
-ETA_RE='available in[^0-9]{0,12}[0-9]+ *\**(minutes?|hours?)'
 
 # 全ページを 1 配列に束ねて最新の CodeRabbit コメントを取る。
 # 注意: この gh では --slurp と --jq は併用不可。--slurp の出力をパイプで jq に渡す。
 # jq -c で valid JSON を返すので、呼び出し側で .body を再パースしても制御文字で壊れない
 # （body を生テキストで取り出して別 jq に食わせると U+0000-001F で parse error になる）。
 fetch_latest() {
-  gh api --paginate --slurp "$API" \
-    | jq -c --arg bot "$CR" \
-      '(add // []) | map(select(.user.login==$bot)) | sort_by(.id) | last // empty'
+  gh api --paginate --slurp "$API" 2>/dev/null \
+    | jq -c 'add | map(select(.user.login=="coderabbitai[bot]")) | sort_by(.created_at) | last // empty' 2>/dev/null
 }
 
-if [ "$DO_TRIGGER" -eq 1 ]; then
-  # baseline: トリガー前の最新 CodeRabbit コメント ID。
-  # これより大きい ID の応答を「トリガー後の応答」とみなす。
-  baseline_json=$(fetch_latest) || die "failed to fetch the baseline CodeRabbit comment"
-  if [ -z "$baseline_json" ]; then
-    baseline=0
-  else
-    baseline=$(printf '%s' "$baseline_json" | jq -r '.id') \
-      || die "failed to parse the baseline CodeRabbit comment"
-  fi
+# baseline: トリガー前の最新 CodeRabbit コメント時刻。これより後の応答を「トリガー後の応答」とみなす。
+baseline=$(fetch_latest | jq -r '.created_at // ""' 2>/dev/null || echo "")
 
+if [ "$DO_TRIGGER" -eq 1 ]; then
   case "$MODE" in
     full) CMD="@coderabbitai full review";;
     incremental|inc) CMD="@coderabbitai review";;
+    *) echo "ERROR: --mode は full|incremental" >&2; exit 2;;
   esac
-  if ! gh pr comment "$PR" --repo "$REPO" --body "$CMD" >/dev/null; then
-    die "failed to post the CodeRabbit review trigger"
-  fi
-  echo "TRIGGERED mode=$MODE pr=#$PR repo=$REPO cmd=\"$CMD\""
+  gh pr comment "$PR" --repo "$REPO" --body "$CMD" >/dev/null \
+    && echo "TRIGGERED mode=$MODE pr=#$PR repo=$REPO cmd=\"$CMD\""
 fi
 
 classify() {
   local body="$1"
-  if printf '%s' "$body" | grep -qiE "rate limit|Review limit reached|$ETA_RE"; then
+  if printf '%s' "$body" | grep -qiE 'rate limit|Review limit reached|available in [0-9]+ (minute|hour)'; then
     echo "RATE_LIMITED"
   elif printf '%s' "$body" | grep -qiE 'Actionable comments posted|Walkthrough|Full review finished|summarize by coderabbit'; then
     echo "POSTED"
-  elif printf '%s' "$body" | grep -qiE 'currently reviewing|review in progress|Reviewing your|Review triggered|Full review triggered'; then
+  elif printf '%s' "$body" | grep -qiE 'currently reviewing|review in progress|Reviewing your'; then
     echo "REVIEWING"
   else
     echo "OTHER"
@@ -148,7 +83,7 @@ classify() {
 report_rate_limit() {
   local body="$1"
   local phrase num unit mins eta
-  phrase=$(printf '%s' "$body" | grep -oiE "$ETA_RE" | head -1 || true)
+  phrase=$(printf '%s' "$body" | grep -oiE 'available in [0-9]+ (minutes?|hours?)' | head -1 || true)
   echo "RATE_LIMIT_DETAIL: ${phrase:-（解除時刻の明記なし。本文を確認）}"
   num=$(printf '%s' "$phrase" | grep -oE '[0-9]+' | head -1 || true)
   unit=$(printf '%s' "$phrase" | grep -oiE 'minute|hour' | head -1 || true)
@@ -157,111 +92,47 @@ report_rate_limit() {
   # BSD date(macOS) → GNU date の順で解除目安時刻を算出（best-effort）
   eta=$(date -u -v+"${mins}"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
         || date -u -d "+${mins} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?")
-  echo "RETRY_AFTER: 約 ${mins} 分後（目安 ${eta}）。解除前に再トリガーしても実レビューは実行されないため、解除まで待つこと。"
-}
-
-rate_limit_has_expired() {
-  local body="$1"
-  local created_at="$2"
-  local phrase num unit mins created_epoch available_epoch now_epoch available_at
-  phrase=$(printf '%s' "$body" | grep -oiE "$ETA_RE" | head -1 || true)
-  num=$(printf '%s' "$phrase" | grep -oE '[0-9]+' | head -1 || true)
-  unit=$(printf '%s' "$phrase" | grep -oiE 'minute|hour' | head -1 || true)
-  [ -n "$num" ] || return 1
-  case "$unit" in hour*) mins=$((num*60));; *) mins=$num;; esac
-
-  # BSD date(macOS) → GNU date の順で投稿時刻を epoch 秒へ変換する（best-effort）。
-  created_epoch=$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$created_at" +%s 2>/dev/null \
-    || date -u -d "$created_at" +%s 2>/dev/null) || return 1
-  available_epoch=$((created_epoch + mins*60))
-  now_epoch=$(date -u +%s 2>/dev/null) || return 1
-  [ "$now_epoch" -ge "$available_epoch" ] || return 1
-
-  # BSD date(macOS) → GNU date の順で解除目安を UTC の ISO 8601 に戻す。
-  available_at=$(date -u -r "$available_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-    || date -u -d "@$available_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-    || echo "?")
-  echo "RATE_LIMIT_EXPIRED_DETAIL: posted_at=$created_at estimated_available_at=$available_at"
-  return 0
+  echo "RETRY_AFTER: 約 ${mins} 分後（目安 ${eta}）。解除前の再トリガーは再び skip されるだけなので待つこと。"
 }
 
 # --no-trigger: baseline 比較や poll をせず、現在の最新コメントをそのまま分類して即返す
 # （新規応答を待つ意味がないため。既にトリガー済みの「今どうなっているか」確認用）
 if [ "$DO_TRIGGER" -eq 0 ]; then
-  latest=$(fetch_latest) || die "failed to fetch the latest CodeRabbit comment"
+  latest=$(fetch_latest)
   if [ -z "$latest" ]; then
-    echo "DETAIL: CodeRabbit のコメントがまだ 1 件もない"
-    echo "STATE=NO_RESPONSE"
+    echo "STATE=NO_RESPONSE  (CodeRabbit のコメントがまだ 1 件もない)"
     exit 0
   fi
-  t=$(printf '%s' "$latest" | jq -r '.created_at') \
-    || die "failed to parse the latest CodeRabbit comment timestamp"
-  body=$(printf '%s' "$latest" | jq -r '.body') \
-    || die "failed to parse the latest CodeRabbit comment body"
+  t=$(printf '%s' "$latest" | jq -r '.created_at')
+  body=$(printf '%s' "$latest" | jq -r '.body')
   state=$(classify "$body")
-  echo "OBSERVED: at=$t (--no-trigger 現状確認)"
-  if [ "$state" = "RATE_LIMITED" ] && rate_limit_has_expired "$body" "$t"; then
-    state="RATE_LIMIT_EXPIRED"
-  fi
+  echo "STATE=$state  at=$t  (--no-trigger 現状確認)"
   [ "$state" = "RATE_LIMITED" ] && report_rate_limit "$body"
   echo "--- CodeRabbit 応答（先頭 15 行） ---"
   printf '%s\n' "$body" | head -15
-  echo "STATE=$state"
   exit 0
 fi
 
 i=0
-fetch_failures=0
-last_state=""
-last_time=""
-last_body=""
 while [ "$i" -lt "$MAX" ]; do
   sleep "$POLL"; i=$((i+1))
-  if ! latest=$(fetch_latest); then
-    fetch_failures=$((fetch_failures+1))
-    echo "WARN: CodeRabbit コメントの取得に失敗しました (${fetch_failures}/${MAX_FETCH_FAILURES})" >&2
-    if [ "$fetch_failures" -ge "$MAX_FETCH_FAILURES" ]; then
-      die "failed to fetch CodeRabbit comments ${MAX_FETCH_FAILURES} consecutive times"
-    fi
-    continue
-  fi
-  fetch_failures=0
+  latest=$(fetch_latest)
   [ -n "$latest" ] || continue
-  comment_id=$(printf '%s' "$latest" | jq -r '.id') \
-    || die "failed to parse the latest CodeRabbit comment ID"
-  [ "$comment_id" -gt "$baseline" ] || continue
-  t=$(printf '%s' "$latest" | jq -r '.created_at') \
-    || die "failed to parse the latest CodeRabbit comment timestamp"
-  body=$(printf '%s' "$latest" | jq -r '.body') \
-    || die "failed to parse the latest CodeRabbit comment body"
-  state=$(classify "$body")
-  if [ "$state" = "REVIEWING" ]; then
-    last_state="$state"
-    last_time="$t"
-    last_body="$body"
-    continue
+  t=$(printf '%s' "$latest" | jq -r '.created_at')
+  newer=0
+  if [ -z "$baseline" ]; then newer=1
+  elif [[ "$t" > "$baseline" ]]; then newer=1
   fi
-  echo "OBSERVED: at=$t (poll $i/$MAX)"
+  [ "$newer" -eq 1 ] || continue
+  body=$(printf '%s' "$latest" | jq -r '.body')
+  state=$(classify "$body")
+  echo "STATE=$state  at=$t  (poll $i/$MAX)"
   [ "$state" = "RATE_LIMITED" ] && report_rate_limit "$body"
   echo "--- CodeRabbit 応答（先頭 15 行） ---"
   printf '%s\n' "$body" | head -15
-  echo "STATE=$state"
   exit 0
 done
 
-if [ "$fetch_failures" -gt 0 ]; then
-  die "monitoring ended after ${fetch_failures} consecutive fetch failure(s)"
-fi
-
-if [ "$last_state" = "REVIEWING" ]; then
-  echo "OBSERVED: at=$last_time (監視窓の終了時点でレビュー実行中)"
-  echo "--- CodeRabbit 応答（先頭 15 行） ---"
-  printf '%s\n' "$last_body" | head -15
-  echo "STATE=REVIEWING"
-  exit 0
-fi
-
-echo "DETAIL: ${MAX}×${POLL}s の監視で baseline 以降の新規 CodeRabbit 応答なし"
+echo "STATE=NO_RESPONSE  (${MAX}×${POLL}s 監視で baseline 以降の新規 CodeRabbit 応答なし)"
 echo "HINT: CodeRabbit は受領時にまず 👀 リアクションのみ付けることがある。--poll/--max を増やすか、少し置いて --no-trigger で再確認する。"
-echo "STATE=NO_RESPONSE"
 exit 0


### PR DESCRIPTION
## 概要

CodeRabbit のレビューを PR にトリガーし、トリガー後に「レビューが起動したか / rate limit で制限中か / 結果が投稿されたか」を監視・判定する新スキル `coderabbit-review-trigger` を追加する。

`@coderabbitai review` / `full review` はコメントを投稿しても Fair Usage Limits（adaptive limit）で silent に skip されることがあり、投げっぱなしだと起動したか分からない。しかも制限中でも応答に「Full review finished」と rate limit 文言が併記されるため、完了と誤読しやすい。本スキルはこの罠を rate limit 優先判定で回避する。

approve は扱わず、既存の `coderabbit-approve` スキルへ委譲する（棲み分けを SKILL.md に明記）。

## 追加物

- `private_dot_claude/skills/coderabbit-review-trigger/SKILL.md`
- `private_dot_claude/skills/coderabbit-review-trigger/scripts/executable_trigger-and-watch.sh`
  - トリガー（full / incremental）→ 応答監視（poll）→ 状態判定（POSTED / REVIEWING / RATE_LIMITED / OTHER / NO_RESPONSE）
  - rate limit 時は "available in N minutes/hours" をパースして解除目安時刻を算出
  - `--no-trigger` で現状確認のみ（rate limit の無駄な消費を避ける）

## テスト計画

- matchmaking-platform の実 PR（#1375 / #1376）で動作確認済み。
  - `--no-trigger` で両 PR を正しく `RATE_LIMITED` 判定し、"Full review finished" 併記に騙されず解除目安時刻を算出できることを確認。
- この gh では `--slurp` と `--jq` が併用不可のため、`--slurp` 出力をパイプで jq に渡す実装に修正済み。
- コメント本文の制御文字（U+0000-001F）で jq が落ちる問題を、`jq -c` で valid JSON 化してから再取得する実装で回避済み。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * CodeRabbitレビューの起動後、コメントを監視して進行状況を自動判定できるようになりました。
  * レビュー結果の投稿、レビュー中、レート制限、応答なしなどの状態を確認できます。
  * レート制限時には、再実行可能になる目安時刻を表示します。
  * レビューを起動せず、現在の状態だけを確認することも可能です。

* **ドキュメント**
  * 標準的な実行手順、再実行の方法、状態ごとの対応を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->