### PR TITLE
fix(statusline): 狭幅・空 display_name でモデル名が消える問題を修正

### DIFF
--- a/private_dot_claude/executable_statusline.sh
+++ b/private_dot_claude/executable_statusline.sh
@@ -27,6 +27,9 @@ fi
 project_dir=$(echo "$input" | jq -r '.workspace.project_dir // empty')
 project=$(basename "${project_dir:-unknown}")
 model=$(echo "$input" | jq -r '.model.display_name // "?"')
+# `//` only substitutes null/false, not "" — an empty display_name would slip
+# through and render a blank model slot. Treat empty/whitespace as unknown too.
+[[ -z "${model//[[:space:]]/}" ]] && model="?"
 used=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
 cost=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 
@@ -311,6 +314,10 @@ fi
 model_seg="$model"
 [[ "$fast_mode" == "true" ]] && model_seg="⚡${model_seg}"
 [[ -n "$effort_level" ]] && model_seg+=" \033[2m·${effort_level}\033[0m"
+# Compact model for the narrow single-row layout: drop the " (1M context)"-style
+# parenthetical so the name still fits beside project/percent/cost.
+model_short="${model%% (*}"
+[[ "$fast_mode" == "true" ]] && model_short="⚡${model_short}"
 lines_seg=""
 if (( lines_add > 0 || lines_del > 0 )); then
   lines_seg="\033[32m+${lines_add}\033[0m/\033[31m-${lines_del}\033[0m"
@@ -359,8 +366,8 @@ elif (( cols >= 60 )); then
   [[ -n "$rl_short" ]] && line2+=" \033[2m|\033[0m ${rl_short}"
 
 else
-  # Narrow: single row — project XX% $X.XX (rate-limit shown only when critical)
-  line1="\033[36m${project}\033[0m \033[${bar_color}m${used}%\033[0m \033[2m${cost_fmt}\033[0m"
+  # Narrow: single row — project model XX% $X.XX (rate-limit shown only when critical)
+  line1="\033[36m${project}\033[0m \033[2m${model_short}\033[0m \033[${bar_color}m${used}%\033[0m \033[2m${cost_fmt}\033[0m"
   (( rl_max >= RL_CRIT )) && [[ -n "$rl_short" ]] && line1+=" ${rl_short}"
 fi
 


### PR DESCRIPTION
## 概要

ステータスライン（`~/.claude/statusline.sh`）で **モデル名が消える 2 経路** を修正します。以前 #59 で「バー全体が空白になる 4 経路」を直しましたが、今回の「モデル名だけが消える」現象は別物で、その修正の対象外でした。

| 経路 | 発生条件 | 修正前 | 修正後 |
|---|---|---|---|
| 狭幅レイアウト | 表示幅が 60 桁未満 | モデル名を含む 2 段目ごと省略され `project 8% $1.24` だけになる | 短縮モデル名を表示（`project Opus 4.8 8% $1.24`） |
| 空文字列すり抜け | `display_name` が空文字列 `""` | モデル欄が空白（`\| \|`） | `?` にフォールバック |

### 詳細

- **空文字列フォールバック**: `jq -r '.model.display_name // "?"'` の `//` は null / false しか拾わないため、空文字列が来ると `?` フォールバックが効かず空欄になっていた。抽出後に空白のみ／空文字列を検出して `?` に寄せる 1 行を追加。
- **狭幅の短縮モデル名**: 狭幅（60 桁未満）の 1 段レイアウトにモデル名を追加。`Opus 4.8 (1M context)` → `Opus 4.8` のようにカッコ内を落として桁を節約する（`${model%% (*}`）。fast モード時は `⚡` を前置。
- 広幅・中幅（60 桁以上）はフル名のままで、挙動は変更していない。

## テスト計画

- [x] `bash -n` 構文チェック通過
- [x] 実入力（Claude Code v2.1.218 が送る JSON）を幅 120 / 70 / 59 / 45 / 30 で描画し、全幅でモデル名が出ることを確認
- [x] 空文字列・空白のみの `display_name` で `?` が出ることを確認（全レイアウト）
- [x] fast モード時に狭幅で `⚡Opus 4.8` が出ることを確認
- [x] 広幅・中幅の描画が従来どおりであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * モデル名が空白の場合、「不明（?）」として表示されるようになりました。
  * ナロー表示時のモデル名を短縮し、よりコンパクトに表示するよう改善しました。
  * 高速モードが有効な場合、モデル名の先頭に「⚡」が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->