### PR TITLE
feat(claude): Claude Code 内蔵の音声入力を有効化し Option+V を割り当てる

### DIFF
--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -75,6 +75,8 @@ chezmoi apply
 
 > **重要（`data.claude.mcpServers` / `enabledPlugins` の安全な運用）**: これらは `chezmoi.toml` の値をそのまま `settings.json` に出力する。①`mcpServers` の `command` / `args` / `env` に API キー・トークンを直書きしない（秘密は環境変数参照や外部 secret manager 経由にする）。②生成済みの `~/.claude/settings.json` を `chezmoi add` / `re-add` しない（秘密が混入した実ファイルをリポジトリに取り込まないため。tmpl 側だけを編集する）。③`enabledPlugins` は信頼済みの marketplace / plugin ID のみ指定する。
 
+<!-- -->
+
 > **重要（コマンドで変えた設定は巻き戻る）**: `/model` や `/voice` のようなスラッシュコマンドは、生成済みの `~/.claude/settings.json` を**直接書き換える**。一方 `settings.json` は tmpl から生成される管理対象なので、コマンドで設定を変えたまま放置すると**次の `chezmoi apply` でテンプレート既定値に巻き戻る**。コマンドで設定を変えたら、必ず `~/.config/chezmoi/chezmoi.toml` の `[data.claude]` も更新すること。対応表は次のとおり（`chezmoi.toml` 自体は chezmoi 管理外のマシン固有ファイルなので、マシンごとに設定する）。
 >
 > | コマンド | 更新する `chezmoi.toml` のキー |
@@ -83,6 +85,8 @@ chezmoi apply
 > | `/voice` | `data.claude.voice.mode` / `data.claude.voice.enabled` |
 >
 > なお `settings.json` がコマンドで書き換わっていると `chezmoi apply` は「chezmoi が書いた後に変更されている」と検出して確認を求める。**確認を求められたら、まず `chezmoi diff` で意図しない巻き戻りが含まれていないかを見る**。`--force` で押し切る前に必ず差分を読むこと。
+
+<!-- -->
 
 > **重要（tmpl の落とし穴）**: tmpl 管理ファイルは `chezmoi re-add` では更新されない（テンプレート構造を壊さないよう実ファイルの差分が取り込まれない）。tmpl の内容を変えるときは **ソースの `*.tmpl` を直接編集 → `chezmoi apply`** で反映すること。`settings.json` のように変数を含まない tmpl でも同様。
 

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -71,9 +71,18 @@ chezmoi apply
 |-----------|--------|-----------------|
 | `~/.gitconfig` | `dot_gitconfig.tmpl` | `{{ .name }}`, `{{ .email }}` |
 | `~/.zshrc` | `dot_zshrc.tmpl` | なし（クリーンアップ済み、将来のマシン分岐用） |
-| `~/.claude/settings.json` | `private_dot_claude/settings.json.tmpl` | `data.claude.model`, `data.claude.effortLevel`, `data.claude.disable1m`, `data.claude.autoCompactWindow`, `data.claude.autoCompactPct`, `data.claude.mcpServers`, `data.claude.enabledPlugins` |
+| `~/.claude/settings.json` | `private_dot_claude/settings.json.tmpl` | `data.claude.model`, `data.claude.effortLevel`, `data.claude.disable1m`, `data.claude.autoCompactWindow`, `data.claude.autoCompactPct`, `data.claude.mcpServers`, `data.claude.enabledPlugins`, `data.claude.voice` |
 
 > **重要（`data.claude.mcpServers` / `enabledPlugins` の安全な運用）**: これらは `chezmoi.toml` の値をそのまま `settings.json` に出力する。①`mcpServers` の `command` / `args` / `env` に API キー・トークンを直書きしない（秘密は環境変数参照や外部 secret manager 経由にする）。②生成済みの `~/.claude/settings.json` を `chezmoi add` / `re-add` しない（秘密が混入した実ファイルをリポジトリに取り込まないため。tmpl 側だけを編集する）。③`enabledPlugins` は信頼済みの marketplace / plugin ID のみ指定する。
+
+> **重要（コマンドで変えた設定は巻き戻る）**: `/model` や `/voice` のようなスラッシュコマンドは、生成済みの `~/.claude/settings.json` を**直接書き換える**。一方 `settings.json` は tmpl から生成される管理対象なので、コマンドで設定を変えたまま放置すると**次の `chezmoi apply` でテンプレート既定値に巻き戻る**。コマンドで設定を変えたら、必ず `~/.config/chezmoi/chezmoi.toml` の `[data.claude]` も更新すること。対応表は次のとおり（`chezmoi.toml` 自体は chezmoi 管理外のマシン固有ファイルなので、マシンごとに設定する）。
+>
+> | コマンド | 更新する `chezmoi.toml` のキー |
+> |---|---|
+> | `/model` | `data.claude.model` |
+> | `/voice` | `data.claude.voice.mode` / `data.claude.voice.enabled` |
+>
+> なお `settings.json` がコマンドで書き換わっていると `chezmoi apply` は「chezmoi が書いた後に変更されている」と検出して確認を求める。**確認を求められたら、まず `chezmoi diff` で意図しない巻き戻りが含まれていないかを見る**。`--force` で押し切る前に必ず差分を読むこと。
 
 > **重要（tmpl の落とし穴）**: tmpl 管理ファイルは `chezmoi re-add` では更新されない（テンプレート構造を壊さないよう実ファイルの差分が取り込まれない）。tmpl の内容を変えるときは **ソースの `*.tmpl` を直接編集 → `chezmoi apply`** で反映すること。`settings.json` のように変数を含まない tmpl でも同様。
 

--- a/private_dot_claude/keybindings.json
+++ b/private_dot_claude/keybindings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": [
+    {
+      "context": "Chat",
+      "bindings": {
+        "meta+v": "voice:pushToTalk"
+      }
+    }
+  ]
+}

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -255,6 +255,13 @@
     }
   },
   "language": "japanese",
+  {{- /*
+    音声入力（/voice）。data.claude.voice でマシンごとに上書きできる。
+    mode は "hold"（押している間だけ録音・送信前に目視できる）か "tap"（タップで開始/停止・自動送信）。
+    重要: /voice コマンドはこの値を settings.json に直接書き込むため、コマンドで変えたら
+    chezmoi.toml の data.claude.voice も更新すること（更新しないと次の apply で巻き戻る）。
+  */}}
+  "voice": {{ dig "claude" "voice" (dict "enabled" true "mode" "hold" "autoSubmit" false) . | toJson }},
   "skipWorkflowUsageWarning": true,
   "teammateMode": "auto",
   "skipAutoPermissionPrompt": true,


### PR DESCRIPTION
## 概要

Claude Code に**音声で指示を出せる**ようにする。外部ツールは導入しない。

一次情報を調べた結果、Claude Code 2.1.100 以降には**公式の音声入力（voice dictation）が内蔵**されており、このマシンの 2.1.220 は要件をすべて満たしていた。よって新しい仕組みを作らず、内蔵機能を有効化し、この環境に合わせてキーを割り当てる。

出典: [Voice dictation（公式ドキュメント）](https://code.claude.com/docs/en/voice-dictation) / [Customize keyboard shortcuts（公式ドキュメント）](https://code.claude.com/docs/en/keybindings)

### 変更内容

| ファイル | 内容 |
|---|---|
| `private_dot_claude/keybindings.json`（新規） | `Chat` コンテキストで `meta+v`（Option+V）を `voice:pushToTalk` に割り当てる |
| `private_dot_claude/settings.json.tmpl` | `voice`（`enabled` / `mode` / `autoSubmit`）を出力。`data.claude.voice` でマシンごとに上書きできる |
| `private_dot_claude/CLAUDE.md` | 「コマンドで変えた設定は巻き戻る」注意書きを追加。テンプレート変数の一覧に `data.claude.voice` を追記 |

### 設計判断の根拠

**hold モードを既定にする（`mode: "hold"`, `autoSubmit: false`）**

キーを押している間だけ録音し、離すと入力欄に挿入されて、Enter を押すまで送信されない。日本語の発話に英語の識別子が混ざると誤認識は必ず起きるので、**送信前に目視で直せること**を最優先にした。tap モードは自動送信を止める設定が公式ドキュメントに見当たらず、かつ入力欄が空のときしか録音を開始できないため、途中まで打った文章への追記ができない。

**`Space` から `Option+V` に変更する**

- 既定の `Space` は hold モードでキーリピート検出のウォームアップがあり、最初の数文字が入力欄に打ち込まれてから消える
- `Space` は日本語 IME の変換キーでもあり、変換操作と押しっぱなし判定が干渉するおそれがある
- 公式ドキュメントが例示する `meta+k` は、この環境の Ghostty 設定の `alt+k`（ペインのサイズ変更）と衝突する
- `Option+V` が空いていることは `ghostty +list-keybinds` で実機確認済み（`alt+v` のバインドなし）

**巻き戻り対策**

`/model` や `/voice` は生成済みの `settings.json` を直接書き換えるため、放置すると次の `chezmoi apply` でテンプレート既定値に戻る。実際にこの作業中、`/model` で選んだ `opus[1m]` がテンプレート既定値に巻き戻る差分が発生した。`voice` を `data.claude.voice` 経由の上書き可能な形にし、運用ルールを `CLAUDE.md` に明記した。

### 補足: なぜ外部ツールを入れないか

Ghostty との相性で 2 つの問題がある。

- Ghostty は `macos-auto-secure-input = true`（既定・有効）で、パスワード入力を検出するとキー入力を保護する。この間、外部ツールのグローバルなホットキーはシステム全体でブロックされる
- 「外部の音声入力ツールの起動キーを押した瞬間に余計な文字がターミナルに入る」という報告がある（[ghostty-org/ghostty discussion #11495](https://github.com/ghostty-org/ghostty/discussions/11495)）

内蔵機能はターミナル内部でキーを処理するため、どちらの影響も受けない。加えて、文字起こしが開発語彙にチューニング済みで、プロジェクト名と git ブランチ名が認識ヒントとして自動投入される。トークンも消費しない。

ターミナル外（エディタ・ブラウザ・Slack 等）への音声入力が必要になったら、別途 superwhisper（ローカル処理可）等を検討する。

## 人手で実行が必要な工程

このリポジトリの変更を適用しただけでは音声入力は使えない。以下は AI が実行できないため、**マージ後に手作業で実施すること**。

### 1. 設定を適用して Claude Code を再起動する

```bash
chezmoi apply          # settings.json と keybindings.json を反映
```

- **成功の確認**: `~/.claude/settings.json` に `"voice"` が入っていること
- Claude Code を再起動する（`keybindings.json` は再起動なしで自動反映されるが、`settings.json` の `voice` は再起動が要る）

### 2. マイク権限を付与する

Claude Code で `/voice` を実行する。

- **成功の確認**: `Voice mode enabled (hold). ...` と表示される。初回は macOS のマイク権限ダイアログが出るので許可する
- **`Voice mode is disabled by your organization's policy` と出た場合**: 組織のコンプライアンス設定で音声入力が無効化されている。管理者に確認する
- **Ghostty が「システム設定 > プライバシーとセキュリティ > マイク」に出てこない場合**:

  ```bash
  tccutil reset Microphone com.mitchellh.ghostty
  ```

  実行後、Ghostty を Cmd+Q で**完全終了**してから再起動し、`/voice` をやり直す（macOS は起動中のプロセスに権限を再要求しない）

### 3. `Option+V` が日本語 IME に横取りされないか検証する

macOS の日本語 IME はキー入力をターミナルより前段で受けるため、理屈だけでは動作を保証できない。次の 3 パターンを試す。

1. 英数モードで `Option+V` を押す → 録音が始まるか
2. 日本語入力モード（未変換の文字なし）で押す → 録音が始まるか
3. 日本語入力モードで未変換の文字がある状態で押す → どうなるか

- **成功の確認**: 1〜3 のいずれでも録音が始まり、入力欄に余計な文字が入らないこと
- **2 か 3 で問題が出た場合**: `keybindings.json` の `meta+v` を `meta+space` または `meta+m` に変更する。どちらも Ghostty・Claude Code のバインドと衝突しないことを確認済み

### 4. 日本語で試し発話する

- **成功の確認**: 発話が入力欄に挿入され、Enter を押すまで送信されないこと
- **使い方**: `Option+V` を押しながら話す → 離す → 目視で直す → Enter
- **長い指示は 1〜3 文ずつに区切って複数回録音する**。カーソル位置に挿入されるので継ぎ足せる。区切るほど目視修正も楽になる

### 5. 運用上の注意

- **英語の識別子は喋らない**。「`handleSubmit` を async にして」ではなく「この関数を async にして」と言い、識別子はタイプするか `@` 補完で指す
- **パス・記号・バージョン番号も口述しない**。意図だけ喋り、具体値はタイプする
- **音声は Anthropic のサーバーへ送られる**（ローカル処理ではない）。周囲に人がいる場では使わない。認証情報や顧客の個人情報は喋らない
- 録音は無音 15 秒、または合計 2 分で自動停止する

### うまくいかないときの切り分け

| 症状 | 見るところ |
|---|---|
| `/voice` 自体がエラー | 認証方式（Claude.ai アカウント必須。`ANTHROPIC_API_KEY` が紛れ込んでいないか） |
| 録音が始まらない | マイク権限（上記の工程 2） |
| `Option+V` で起動しない | `keybindings.json` の構文 → Ghostty が同キーを消費していないか → IME 状態依存か（英数モードで再試行して切り分け） |
| 冒頭の音声が欠ける | 既知の不具合（[#40528](https://github.com/anthropics/claude-code/issues/40528) 初期化遅延）。押してから一呼吸おいて話し始める |
| ときどき全く認識されない | 既知の不具合（[#40523](https://github.com/anthropics/claude-code/issues/40523)）。再試行する |
| 入力欄に変な文字が入る | hold モードのウォームアップ症状。修飾キーへのリバインドが効いていない |

## テスト計画

### 自動で確認済み

- `keybindings.json` が妥当な JSON であること（`python3 -m json.tool`）
- `settings.json.tmpl` が妥当な JSON に展開されること（`chezmoi execute-template` → `json.loads`）
- `data.claude.voice` 未定義のマシンで既定値 `{"autoSubmit":false,"enabled":true,"mode":"hold"}` が出ること
- `data.claude.voice` で上書きしたマシンでその値が出ること（`mode = "tap"` で検証）
- `Option+V` が Ghostty のバインドと衝突しないこと（`ghostty +list-keybinds` に `alt+v` なし。`alt+k` は確かにペインのサイズ変更に割り当て済み）

### 人手での確認

上記「人手で実行が必要な工程」の各項目にある「成功の確認」を参照。

## 既知の未解決事項（このPRの対象外）

`dot_gitconfig.tmpl` の 15 行目と 20 行目が `git_signing_enabled` を参照しているが、`chezmoi.toml` に定義がないため、**引数なしの `chezmoi apply` が `.gitconfig` で失敗する**。このPRの変更とは無関係の既存の問題。commit 署名を使うかどうかの判断が必要なため、別途対応する。回避策として、ファイルを個別指定した `chezmoi apply <path>` は成功する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 音声入力の有効化、操作モード（hold/tap）、自動送信を設定できるようになりました。
  * チャット中に **Meta+V** でプッシュ・トゥ・トークを利用できます。
* **ドキュメント**
  * 音声設定やスラッシュコマンド変更時の確認手順を追記しました。
  * 設定変更が適用時に巻き戻る場合の注意点と差分確認方法を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->