### PR TITLE
fix(gitconfig): chezmoi apply の失敗を直し SSH commit 署名を有効化できるようにする

### DIFF
--- a/dot_config/git/allowed_signers.tmpl
+++ b/dot_config/git/allowed_signers.tmpl
@@ -1,0 +1,15 @@
+{{- /*
+  SSH commit 署名を手元で検証するための「信頼する署名者」一覧。
+  git の gpg.ssh.allowedSignersFile がこのファイルを読む。
+
+  中身は chezmoi apply の時点でローカルの公開鍵ファイルから組み立てる。
+  リポジトリには鍵そのものを置かない（ここにあるのは組み立て方の指示だけ）。
+
+  署名を使わないマシン（git_signing_enabled が未定義 or false）では空を出力する。
+  chezmoi は空のファイルを作らないので、そのマシンにこのファイルは生成されない。
+*/}}
+{{- $signingEnabled := dig "git_signing_enabled" false . }}
+{{- $signingKey := dig "git_signing_key" "" . }}
+{{- if and $signingEnabled $signingKey -}}
+{{ .email }} {{ output "cat" $signingKey | trim }}
+{{ end -}}

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -35,6 +35,8 @@
 {{- if $signingEnabled }}
 [gpg]
 	format = ssh
+[gpg "ssh"]
+	allowedSignersFile = {{ joinPath .chezmoi.homeDir ".config" "git" "allowed_signers" }}
 [commit]
 	gpgsign = true
 {{- end }}

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -9,15 +9,30 @@
 	ps = push
 	mg = merge
 
+{{- /*
+  SSH commit 署名はマシンごとの opt-in。chezmoi.toml に次の 2 つを書いたマシンでのみ有効になる。
+
+      git_signing_enabled = true
+      git_signing_key = "/Users/<user>/.ssh/<key>.pub"   # 公開鍵のパス（絶対パス）
+
+  未定義のマシンでは署名なしの .gitconfig が生成される。
+  `default false .git_signing_enabled` ではなく `dig` を使うのは、chezmoi が未定義キーの
+  参照自体をエラーにするため（default が働く前に停止し、chezmoi apply が丸ごと失敗する）。
+*/}}
+{{- $signingEnabled := dig "git_signing_enabled" false . }}
+{{- $signingKey := dig "git_signing_key" "" . }}
+{{- if and $signingEnabled (not $signingKey) }}
+{{- fail "chezmoi.toml: git_signing_enabled = true のときは git_signing_key（公開鍵の絶対パス）も設定してください" }}
+{{- end }}
 [user]
 	name = {{ .name }}
 	email = {{ .email }}
-{{- if default false .git_signing_enabled }}
-	signingkey = {{ .git_signing_key }}
+{{- if $signingEnabled }}
+	signingkey = {{ $signingKey }}
 {{- end }}
 [core]
 	filemode = false
-{{- if default false .git_signing_enabled }}
+{{- if $signingEnabled }}
 [gpg]
 	format = ssh
 [commit]

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -75,6 +75,8 @@ chezmoi apply
 
 > **重要（`data.claude.mcpServers` / `enabledPlugins` の安全な運用）**: これらは `chezmoi.toml` の値をそのまま `settings.json` に出力する。①`mcpServers` の `command` / `args` / `env` に API キー・トークンを直書きしない（秘密は環境変数参照や外部 secret manager 経由にする）。②生成済みの `~/.claude/settings.json` を `chezmoi add` / `re-add` しない（秘密が混入した実ファイルをリポジトリに取り込まないため。tmpl 側だけを編集する）。③`enabledPlugins` は信頼済みの marketplace / plugin ID のみ指定する。
 
+<!-- -->
+
 > **SSH commit 署名の有効化（マシンごとの opt-in）**: 既定は署名なし。有効にしたいマシンだけ `~/.config/chezmoi/chezmoi.toml` の `[data]` に次の 2 つを書く。片方だけだとテンプレートの展開がエラーで止まる。
 >
 > ```toml
@@ -86,6 +88,8 @@ chezmoi apply
 > 加えて、その公開鍵を GitHub に **Signing Key として登録する**（Settings → SSH and GPG keys → New SSH key → Key type = Signing Key）。認証用（Authentication Key）として登録済みでも、署名用は別枠での登録が必要。登録しないと GitHub 上で Unverified のままになる。
 >
 > 手元で `git log --show-signature` を通すための「信頼する署名者」一覧（`gpg.ssh.allowedSignersFile`）は自動で用意される。`dot_config/git/allowed_signers.tmpl` が `chezmoi apply` の時点でローカルの公開鍵から `~/.config/git/allowed_signers` を生成する（**鍵の中身はリポジトリに入らない**）。署名を使わないマシンでは、このファイルは生成されない。
+
+<!-- -->
 
 > **重要（tmpl の落とし穴）**: tmpl 管理ファイルは `chezmoi re-add` では更新されない（テンプレート構造を壊さないよう実ファイルの差分が取り込まれない）。tmpl の内容を変えるときは **ソースの `*.tmpl` を直接編集 → `chezmoi apply`** で反映すること。`settings.json` のように変数を含まない tmpl でも同様。
 

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -85,7 +85,7 @@ chezmoi apply
 >
 > 加えて、その公開鍵を GitHub に **Signing Key として登録する**（Settings → SSH and GPG keys → New SSH key → Key type = Signing Key）。認証用（Authentication Key）として登録済みでも、署名用は別枠での登録が必要。登録しないと GitHub 上で Unverified のままになる。
 >
-> 手元で `git log --show-signature` を通したい場合は、信頼する署名者の一覧ファイル（`gpg.ssh.allowedSignersFile`）の設定が別途必要。GitHub 上の Verified 表示には不要。
+> 手元で `git log --show-signature` を通すための「信頼する署名者」一覧（`gpg.ssh.allowedSignersFile`）は自動で用意される。`dot_config/git/allowed_signers.tmpl` が `chezmoi apply` の時点でローカルの公開鍵から `~/.config/git/allowed_signers` を生成する（**鍵の中身はリポジトリに入らない**）。署名を使わないマシンでは、このファイルは生成されない。
 
 > **重要（tmpl の落とし穴）**: tmpl 管理ファイルは `chezmoi re-add` では更新されない（テンプレート構造を壊さないよう実ファイルの差分が取り込まれない）。tmpl の内容を変えるときは **ソースの `*.tmpl` を直接編集 → `chezmoi apply`** で反映すること。`settings.json` のように変数を含まない tmpl でも同様。
 

--- a/private_dot_claude/CLAUDE.md
+++ b/private_dot_claude/CLAUDE.md
@@ -69,11 +69,23 @@ chezmoi apply
 
 | ターゲット | ソース | テンプレート変数 |
 |-----------|--------|-----------------|
-| `~/.gitconfig` | `dot_gitconfig.tmpl` | `{{ .name }}`, `{{ .email }}` |
+| `~/.gitconfig` | `dot_gitconfig.tmpl` | `{{ .name }}`, `{{ .email }}`, `git_signing_enabled`, `git_signing_key` |
 | `~/.zshrc` | `dot_zshrc.tmpl` | なし（クリーンアップ済み、将来のマシン分岐用） |
 | `~/.claude/settings.json` | `private_dot_claude/settings.json.tmpl` | `data.claude.model`, `data.claude.effortLevel`, `data.claude.disable1m`, `data.claude.autoCompactWindow`, `data.claude.autoCompactPct`, `data.claude.mcpServers`, `data.claude.enabledPlugins` |
 
 > **重要（`data.claude.mcpServers` / `enabledPlugins` の安全な運用）**: これらは `chezmoi.toml` の値をそのまま `settings.json` に出力する。①`mcpServers` の `command` / `args` / `env` に API キー・トークンを直書きしない（秘密は環境変数参照や外部 secret manager 経由にする）。②生成済みの `~/.claude/settings.json` を `chezmoi add` / `re-add` しない（秘密が混入した実ファイルをリポジトリに取り込まないため。tmpl 側だけを編集する）。③`enabledPlugins` は信頼済みの marketplace / plugin ID のみ指定する。
+
+> **SSH commit 署名の有効化（マシンごとの opt-in）**: 既定は署名なし。有効にしたいマシンだけ `~/.config/chezmoi/chezmoi.toml` の `[data]` に次の 2 つを書く。片方だけだとテンプレートの展開がエラーで止まる。
+>
+> ```toml
+> [data]
+>     git_signing_enabled = true
+>     git_signing_key = "/Users/<user>/.ssh/<key>.pub"   # 公開鍵の絶対パス
+> ```
+>
+> 加えて、その公開鍵を GitHub に **Signing Key として登録する**（Settings → SSH and GPG keys → New SSH key → Key type = Signing Key）。認証用（Authentication Key）として登録済みでも、署名用は別枠での登録が必要。登録しないと GitHub 上で Unverified のままになる。
+>
+> 手元で `git log --show-signature` を通したい場合は、信頼する署名者の一覧ファイル（`gpg.ssh.allowedSignersFile`）の設定が別途必要。GitHub 上の Verified 表示には不要。
 
 > **重要（tmpl の落とし穴）**: tmpl 管理ファイルは `chezmoi re-add` では更新されない（テンプレート構造を壊さないよう実ファイルの差分が取り込まれない）。tmpl の内容を変えるときは **ソースの `*.tmpl` を直接編集 → `chezmoi apply`** で反映すること。`settings.json` のように変数を含まない tmpl でも同様。
 


### PR DESCRIPTION
## 概要

`chezmoi apply`（引数なしの全体適用）が `.gitconfig` で必ず失敗する不具合を直す。あわせて SSH commit 署名の有効化手順を `CLAUDE.md` に明記する。

### 何が起きていたか

`dot_gitconfig.tmpl` は署名設定を `{{- if default false .git_signing_enabled }}` で囲み、「未定義なら署名なし」を意図していた。しかし **chezmoi は未定義キーの参照自体をエラーにする**ため、`default` が働く前にテンプレートの展開が止まっていた。

```
chezmoi: .gitconfig: template: dot_gitconfig.tmpl:15:21:
  executing "dot_gitconfig.tmpl" at <.git_signing_enabled>:
  map has no entry for key "git_signing_enabled"
```

結果として次の2つが起きていた。

- **`chezmoi.toml` に `git_signing_enabled` を書いていないマシンでは、`chezmoi apply` が丸ごと失敗する**。新規マシンのセットアップは必ずここで止まる
- **`.gitconfig` が 2026-05-14 以降、一度も再生成されていない**。署名を有効化する意図で入った変更（`a9db4e2` / `f5614b0`）が、ローカルに反映されないままだった

### 変更内容

| ファイル | 内容 |
|---|---|
| `dot_gitconfig.tmpl` | `default false .x` を `dig "x" false .` に置き換え、未定義でもエラーにならないようにする。`git_signing_enabled = true` なのに `git_signing_key` が無い場合は `fail` で明示的に停止させる。設定方法をコメントで記載 |
| `dot_config/git/allowed_signers.tmpl`（新規） | 手元での署名検証に使う「信頼する署名者」一覧を、適用時にローカルの公開鍵から生成する。**鍵の中身はリポジトリに入らない**。署名を使わないマシンでは空を出力し、chezmoi が空ファイルを作らないためファイル自体が生成されない |
| `private_dot_claude/CLAUDE.md` | テンプレート変数の一覧に `git_signing_enabled` / `git_signing_key` を追記。SSH commit 署名を有効にする手順（chezmoi.toml の2値 + GitHub への Signing Key 登録）を追記 |

### 設計方針

**署名はマシンごとの opt-in、既定は署名なし**という元の設計を維持する。`chezmoi.toml` は chezmoi 管理外のマシン固有ファイルなので、署名を使いたいマシンだけがそこで有効化する。**秘密鍵はリポジトリに一切入らない**（設定するのは真偽値と、公開鍵の絶対パスのみ）。

`fail` を入れたのは、`git_signing_enabled = true` だけ書いて鍵のパスを忘れると、`signingkey` が空の `.gitconfig` が黙って生成され、コミット時に分かりにくいエラーになるため。設定漏れを展開時点で気づけるようにする。

## テスト計画

### 自動で確認済み

`chezmoi execute-template` に3パターンの設定を与えて展開結果を確認した。

| ケース | 期待 | 結果 |
|---|---|---|
| `git_signing_enabled` 未定義（既存マシン・新規マシン） | 署名なしの `.gitconfig` が生成される。エラーなし | ✅ `[gpg]` / `[commit]` / `signingkey` が出力されない |
| `git_signing_enabled = true` + `git_signing_key` あり | 署名ありの `.gitconfig` が生成される | ✅ `signingkey` / `[gpg] format = ssh` / `[commit] gpgsign = true` が出力される |
| `git_signing_enabled = true` のみ（鍵のパス漏れ） | 明示的なエラーで停止する | ✅ `fail` のメッセージで停止 |
| 署名ありのマシンで `allowed_signers` を生成 | `<メールアドレス> ssh-ed25519 <公開鍵>` の 1 行 | ✅ 生成を確認 |
| 署名なしのマシンで `allowed_signers` を生成 | 空を出力しファイルが作られない | ✅ 出力 0 文字 |
| 実際に署名して手元で検証 | `Good "git" signature` / `%G?` が `G` | ✅ 実機で確認 |

### 人手で実行が必要な工程

このPRをマージしただけでは、**エラーが消えるだけで署名は有効にならない**。署名を使いたいマシンで以下を実施すること。使わないマシンでは何もしなくてよい（`chezmoi apply` が通るようになる）。

#### 1. 公開鍵を GitHub に Signing Key として登録する

GitHub の Settings → SSH and GPG keys → New SSH key を開き、**Key type を `Signing Key`** にして公開鍵を貼り付ける。

- **注意**: 認証用（Authentication Key）として同じ鍵を登録済みでも、**署名用は別枠での登録が必要**。登録しないとコミットは GitHub 上で Unverified のままになる
- **成功の確認**: Settings の一覧に「Signing keys」の見出しで鍵が表示される

#### 2. `chezmoi.toml` に2つの値を書く

`~/.config/chezmoi/chezmoi.toml` の `[data]` に追記する（このファイルは chezmoi 管理外のマシン固有ファイル）。

```toml
[data]
    git_signing_enabled = true
    git_signing_key = "/Users/<user>/.ssh/<key>.pub"
```

- **鍵のパスは絶対パスで書く**
- 片方だけだと展開時に `fail` で止まる

#### 3. 適用して確認する

```bash
chezmoi apply
git config --global --get commit.gpgsign      # -> true
git config --global --get user.signingkey     # -> 公開鍵の絶対パス
```

- **成功の確認**: 上の2つのコマンドが期待値を返すこと
- そのあと何かコミットして GitHub 上で **Verified** バッジが付くこと

#### 4. 手元での署名検証（自動・作業不要）

`~/.config/git/allowed_signers` は `chezmoi apply` が自動生成し、`gpg.ssh.allowedSignersFile` も自動で設定される。手作業は不要。

- **成功の確認**: `git log --show-signature -1` が `Good "git" signature` を表示し、`git log -1 --pretty="%G?"` が `G` を返すこと

### うまくいかないときの切り分け

| 症状 | 見るところ |
|---|---|
| `chezmoi apply` が `fail` のメッセージで止まる | `git_signing_key` の書き漏れ |
| コミット時に署名エラー | 鍵のパスが正しいか。パスフレーズ付きの鍵なら `ssh-add` でエージェントに登録されているか |
| GitHub で Unverified のまま | 鍵が **Signing Key** として登録されているか（Authentication Key だけでは足りない）。コミットのメールアドレスが GitHub アカウントに登録済みか |
| 手元で「不明な署名者」と出る | `~/.config/git/allowed_signers` が生成されているか。生成されていなければ `git_signing_key` のパスが実在するか確認する。GitHub 側の表示には影響しない |

## 関連

音声入力の PR（#81）で `chezmoi apply` を実行した際に表面化した既存の不具合。#81 とは独立した変更で、依存関係はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - SSHによるGitコミット署名に対応しました。
  - 署名者の公開鍵を使用したコミット検証を設定できるようになりました。
  - 署名機能は明示的に有効化した場合のみ適用されます。

- **ドキュメント**
  - SSHコミット署名の設定手順と検証条件を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->