### PR TITLE
fix(self-review): レビュー失敗が「指摘 0 件」に見える問題を直す

### DIFF
--- a/private_dot_claude/skills/self-review/SKILL.md
+++ b/private_dot_claude/skills/self-review/SKILL.md
@@ -34,7 +34,7 @@ Claude Code 内蔵 `/simplify` と外部レビュアーを組み合わせ、**1 
 
 | パラメータ | デフォルト | 説明 |
 |-----------|----------|------|
-| `--strategy` | `auto` | `auto`（diff 規模で simple/standard を自動判定）/ `simple`（Simplify のみ）/ `standard`（bug + security 並列）/ `deep`（design + macro 観点 goal-achievement/spec-consistency + ultrareview 込みの 5 観点並列） |
+| `--strategy` | `auto` | `auto`（diff 規模で simple/standard/docs-only を自動判定）/ `simple`（Simplify のみ）/ `standard`（bug + security 並列）/ `deep`（design + macro 観点 goal-achievement/spec-consistency + ultrareview 込みの 5 観点並列）/ `docs-only`（変更ファイルがすべて非コードのとき自動判定。Simplify と外部レビューを両方スキップし、司令塔が事実照合を行う） |
 | `--scope` | `changed` | `changed`（ベースブランチからの差分）/ `staged`（ステージ済み）/ `all`（全ファイル） |
 | `--max-iterations` | 1（`--deep` 時は 3） | 最大ループ回数。通常は 1 パスで十分 |
 | `--skip-simplify` | false | Simplify をスキップ |
@@ -106,11 +106,14 @@ Claude Code 内蔵 `/simplify` と外部レビュアーを組み合わせ、**1 
    - `staged`: `git diff --cached --name-only`
    - `all`: 全トラッキングファイル
 5. 対象ファイルがなければ「レビュー対象がありません」と報告して終了
-6. `--strategy auto` の場合、diff 規模と opt-in フラグで戦略を決定する:
+6. `--strategy auto` の場合、次の優先順位で戦略を決定する:
+   - **明示指定**（`--strategy simple|standard|deep|docs-only`）: そのまま尊重し、以降の判定はすべて上書きする
    - **`--deep` 指定時**: `deep` を強制
+   - **docs-only 判定**（`--force-external` が指定されている場合はこの判定を無視して通常の経路に入る）:
+     変更ファイルが**すべて非コード**（拡張子が `.md` / `.markdown` / `.txt` / `.rst` / `.adoc`、
+     またはパスが `docs/` 配下）なら `docs-only` と判定する。`simple` / `standard` の閾値判定より**先に**評価する
    - **diff 行数 ≤ 30 かつ ファイル数 ≤ 3 かつ `--force-external` なし**: `simple`（Simplify のみ、外部レビュー自動スキップ）
    - **それ以外**: `standard`（bug + security の 2 並列）
-   - **明示指定**（`--strategy simple|standard|deep`）はそのまま尊重し閾値判定を上書き
 7. `classification-guide.md` は通常 **読み込まない**（分類は外部レビュアー側で済ませているため）。
    明らかな誤分類が多発する場合のみ [references/classification-guide.md](references/classification-guide.md) を読み込んで手動補正する
 8. 初期状態をユーザーに報告する:
@@ -145,6 +148,9 @@ macro 観点（goal-achievement / spec-consistency）は **diff だけでは評�
 ### Step 1: Simplify 実行（原則 Claude Code 内蔵 `/simplify`）
 
 `--skip-simplify` でなければ Simplify を実行する。
+
+**`docs-only` strategy のときは Simplify を実行しない**。理由をユーザーへ 1 行報告する
+（趣旨: 「Simplify はコードの再利用性・複雑さ・効率を見るため、Markdown には作用対象が無い」）。
 
 **原則: 司令塔（セッションのメインモデル）自身が Claude Code 内蔵 `/simplify` スキルを起動する**。Codex 委譲は
 レート消費が大きいため `--simplify-via=codex` 指定時のみの opt-in に降格した。
@@ -202,8 +208,9 @@ Step 1 で変更があった場合、**stash や中間コミットを作らず�
 
 ### Step 3: 外部レビュー実行
 
-`--skip-external` または `simple` strategy（`--force-external` 無し）の場合はこの Step を丸ごとスキップ。
-それ以外は strategy に応じて以下を実行する。
+`--skip-external` または `simple` / `docs-only` strategy（`--force-external` 無し）の場合はこの Step を
+丸ごとスキップ。`docs-only` の場合は理由をユーザーへ 1 行報告する（趣旨: 「bug / security の外部レビューは
+実行コードを対象とするため、Markdown には作用対象が無い」）。それ以外は strategy に応じて以下を実行する。
 
 #### 共通: 対象ファイル添付（B-1: 誤検知防止、`--attach-full-file` opt-in）
 
@@ -220,11 +227,22 @@ Step 1 で変更があった場合、**stash や中間コミットを作らず�
 
 | CLI | 必須フラグ |
 |-----|----------|
-| `claude -p` | `--output-format json --json-schema "$(cat ${CLAUDE_SKILL_DIR}/references/schemas/finding-schema.json)"`（フラグ引数は **JSON 文字列**、ファイルパスではない）、`--permission-mode dontAsk`、`--allowedTools "Read"`。`ANTHROPIC_API_KEY` 設定時のみ追加で `--bare`（OAuth ログイン環境では `--bare` を付けると認証エラー `Not logged in` になるため Step 0 で自動判定） |
-| `scripts/codex-review.sh`（内部で `codex exec` を実行） | **Bash から `codex exec` を直接叩かない**（PreToolUse フック `block-codex-direct.py` にブロックされる）。呼び出しはスキル同梱の [scripts/codex-review.sh](scripts/codex-review.sh) を経由する（スクリプトファイルの呼び出しは同フックの検査対象外）。スクリプト内部でサブコマンド **`exec`**（`exec review` は `--output-schema` 非対応のため使わない）、`--output-schema`、`--output-last-message <tmpfile>`、`--sandbox read-only` を組み立てる。`codex >= 0.122` の環境では `--ignore-user-config` / `--ignore-rules` も付与（古いバージョンでは省略） |
+| `claude -p` | `--output-format json --json-schema "$(cat "$CLAUDE_SCHEMA")"`（フラグ引数は **JSON 文字列**、ファイルパスではない）、`--permission-mode dontAsk`、`--allowedTools "Read"`。`ANTHROPIC_API_KEY` 設定時のみ追加で `--bare`（OAuth ログイン環境では `--bare` を付けると認証エラー `Not logged in` になるため Step 0 で自動判定）。**`$CLAUDE_SCHEMA` は `finding-schema.json` から `jq 'del(."$schema")'` で `$schema` キーを除去した一時ファイル**（`--json-schema` は `$schema` キー付きスキーマを `no schema with key or ref "..."` エラーで拒否するため。`finding-schema.json` 自体は変更しない）。呼び出しは `scripts/lib-timeout.sh` の `_timeout` でラップする（macOS に `timeout` コマンドは無い） |
+| `scripts/codex-review.sh`（内部で `codex exec` を実行） | **Bash から `codex exec` を直接叩かない**（PreToolUse フック `block-codex-direct.py` にブロックされる）。呼び出しはスキル同梱の [scripts/codex-review.sh](scripts/codex-review.sh) を経由する（スクリプトファイルの呼び出しは同フックの検査対象外）。スクリプト内部でサブコマンド **`exec`**（`exec review` は `--output-schema` 非対応のため使わない）、`--output-schema`、`--output-last-message <tmpfile>`、`--sandbox read-only` を組み立て、`_timeout`（既定 300 秒、`CODEX_REVIEW_TIMEOUT` で上書き可）でラップする。`codex >= 0.122` の環境では `--ignore-user-config` / `--ignore-rules` も付与（古いバージョンでは省略） |
 | `claude ultrareview` | `--json`（exit code 0=完了/1=失敗/130=Ctrl-C を尊重）。Pro/Max は無料枠 3 回、以降は課金 |
 
 呼び出し例とプロンプト詳細は [references/review-prompts.md](references/review-prompts.md) を参照。
+
+#### 共通: レビュアー出力の検証（[scripts/validate-findings.sh](scripts/validate-findings.sh)）
+
+シェルの終了コードが 0 でも、出力が空・壊れた JSON・スキーマ違反であることがある。
+**すべてのレビュアー呼び出しの直後に [scripts/validate-findings.sh](scripts/validate-findings.sh) を通し**、
+検証・正規化してから結果を採用する。詳細な仕様（claude -p / codex-review.sh の出力構造の違いを含む）は
+[references/review-prompts.md](references/review-prompts.md) の「共通: レビュアー出力の検証」節を参照。
+
+- 検証に失敗したレビュアーは「失敗」として扱い、fallback 順に次を試す
+- **検証を通過していない出力を「指摘 0 件」と解釈してはならない**
+- Step 8 の最終サマリに、各観点が検証を通過したかどうかを含める
 
 #### strategy: standard（デフォルト・bug + security の 2 並列）
 
@@ -262,6 +280,19 @@ Step 1 で変更があった場合、**stash や中間コミットを作らず�
 
 `--deep` 無し で `--with-design` のみ指定された場合、standard の 2 並列に design 観点を加えて 3 並列で起動する。
 ultrareview は明示的に `--ultrareview` を付けない限り起動しない。
+
+#### strategy: docs-only（外部レビューをスキップし、司令塔が事実照合する）
+
+`docs-only` では bug / security の外部レビューを呼ばない。ただし「レビューを飛ばして問題なしで終える」のは
+危険なので、代わりに**司令塔（セッションのメインモデル）自身が事実照合を行う**。最低限、次を確認する:
+
+- 文書が参照している Issue 番号・Pull Request 番号が実在し、内容が食い違っていないか
+- 相対リンクの参照先が実在するか
+- Mermaid 図があれば構文が通るか（`~/.claude/docs/mermaid-conventions.md` の検証レシピ）
+- 記述している日付・固有名詞が事実と一致するか
+
+この事実照合を専用の観点としてスクリプト化するのは現時点では未実装。将来の課題として
+[docs/improvement-ideas.md](docs/improvement-ideas.md) に記録してある。
 
 #### レビュアーが全滅した場合
 
@@ -358,6 +389,7 @@ git commit -m "refactor: self-review (simplify + review fixes)"
 以下の条件に 1 つでも該当したら、以降のステップをスキップして Step 8 へ直行する:
 
 - **`simple` strategy**（diff ≤ 30 行 かつ ファイル ≤ 3、`--force-external` なし）→ Step 3 を全スキップし、Simplify 結果のみで Step 6 → Step 8 へ
+- **`docs-only` strategy**（変更ファイルがすべて非コード）→ Step 1（Simplify）と Step 3（外部レビュー）を両方スキップし、司令塔の事実照合結果のみで Step 8 へ
 - 外部レビュー結果の findings が 0 件 かつ Simplify でも変更なし → 何もコミットせず終了
 - critical が 0 件 かつ judgment が 0 件 → judgment フェーズをスキップ（auto-fix のみ適用して Step 6 へ）
 
@@ -373,7 +405,7 @@ git commit -m "refactor: self-review (simplify + review fixes)"
 - primary → fallback が発生したレビュアーの内訳
 - judgment が 4 件以上発生して info に格下げされた件数（あれば）
 - 残存する info 項目（将来の改善提案）
-- 終了理由（収束完了 / 上限到達 / simple 早期終了）
+- 終了理由（収束完了 / 上限到達 / simple 早期終了 / docs-only 早期終了）
 
 ## エラーハンドリング
 
@@ -383,7 +415,7 @@ git commit -m "refactor: self-review (simplify + review fixes)"
 | Gemini 429 (MODEL_CAPACITY_EXHAUSTED) | サーバー容量不足 | scripts/gemini-review.sh が 1 回リトライ → モデルフォールバック → クールダウン記録し、`[self-review] gemini unavailable...` を返して終了。呼び出し側は `--with-gemini` を外すか手動続行で対応する |
 | Codex レート制限 | 5時間ウィンドウ超過 | 次のレビュアー (Claude-p) へフォールバック。Simplify を Codex に委譲する `--simplify-via=codex` は特にレートを食う |
 | Codex `--output-schema` 違反 | gpt-5-codex 系モデルでツール起動時に schema が無視される既知バグ | `-c model=gpt-5.6-terra`（default、`CODEX_REVIEW_MODEL` で上書き可。terra は schema 順守を確認済み）+ `--output-last-message` の組合せで回避。Schema 違反検出時は Claude-p フォールバック |
-| Claude-p タイムアウト | ネットワークまたはAPI負荷 | 120秒タイムアウトで次のレビュアーへ |
+| Claude-p タイムアウト | ネットワークまたはAPI負荷 | `scripts/lib-timeout.sh` の `_timeout` でラップし 120 秒でタイムアウト、次のレビュアーへ。macOS に `timeout` コマンドは無いので、素の `timeout` を使わないこと |
 | ultrareview 失敗 (`exit 1`) | 課金枠超過 / API 障害 | 通常の `claude -p --bare` にフォールバック |
 | 全レビュアー失敗 | 全CLIが利用不可 | ユーザーに報告、Simplify 結果のみで判断を仰ぐ |
 | git コミット失敗 | pre-commit hook 等 | エラー内容を表示し、ユーザーに対応を確認 |

--- a/private_dot_claude/skills/self-review/SKILL.md
+++ b/private_dot_claude/skills/self-review/SKILL.md
@@ -229,7 +229,7 @@ Step 1 で変更があった場合、**stash や中間コミットを作らず�
 |-----|----------|
 | `claude -p` | `--output-format json --json-schema "$(cat "$CLAUDE_SCHEMA")"`（フラグ引数は **JSON 文字列**、ファイルパスではない）、`--permission-mode dontAsk`、`--allowedTools "Read"`。`ANTHROPIC_API_KEY` 設定時のみ追加で `--bare`（OAuth ログイン環境では `--bare` を付けると認証エラー `Not logged in` になるため Step 0 で自動判定）。**`$CLAUDE_SCHEMA` は `finding-schema.json` から `jq 'del(."$schema")'` で `$schema` キーを除去した一時ファイル**（`--json-schema` は `$schema` キー付きスキーマを `no schema with key or ref "..."` エラーで拒否するため。`finding-schema.json` 自体は変更しない）。呼び出しは `scripts/lib-timeout.sh` の `_timeout` でラップする（macOS に `timeout` コマンドは無い） |
 | `scripts/codex-review.sh`（内部で `codex exec` を実行） | **Bash から `codex exec` を直接叩かない**（PreToolUse フック `block-codex-direct.py` にブロックされる）。呼び出しはスキル同梱の [scripts/codex-review.sh](scripts/codex-review.sh) を経由する（スクリプトファイルの呼び出しは同フックの検査対象外）。スクリプト内部でサブコマンド **`exec`**（`exec review` は `--output-schema` 非対応のため使わない）、`--output-schema`、`--output-last-message <tmpfile>`、`--sandbox read-only` を組み立て、`_timeout`（既定 300 秒、`CODEX_REVIEW_TIMEOUT` で上書き可）でラップする。`codex >= 0.122` の環境では `--ignore-user-config` / `--ignore-rules` も付与（古いバージョンでは省略） |
-| `claude ultrareview` | `--json`（exit code 0=完了/1=失敗/130=Ctrl-C を尊重）。Pro/Max は無料枠 3 回、以降は課金 |
+| `claude ultrareview` | `--json`（exit code 0=完了/1=失敗/130=Ctrl-C を尊重）。Pro/Max は無料枠 3 回、以降は課金。**呼び出しは `scripts/lib-timeout.sh` の `_timeout` でラップする**（他の 2 つと同じ。包まないと、CLI が応答しなくなったときにレビュー全体が止まり、fallback にも進めない）。タイムアウトしたら bug 観点の fallback（`claude -p`）へ進む |
 
 呼び出し例とプロンプト詳細は [references/review-prompts.md](references/review-prompts.md) を参照。
 
@@ -242,6 +242,10 @@ Step 1 で変更があった場合、**stash や中間コミットを作らず�
 
 - 検証に失敗したレビュアーは「失敗」として扱い、fallback 順に次を試す
 - **検証を通過していない出力を「指摘 0 件」と解釈してはならない**
+- **`claude ultrareview` の出力も例外にしない。** ultrareview は `finding-schema.json` と
+  完全には一致しない形を返しうるため、まず `aspect` / `category` / `severity` を補う正規化を
+  かけ、**その結果を `validate-findings.sh` へ通す**。ここで失敗したら、ほかのレビュアーと
+  同じく bug 観点の fallback（`claude -p`）へ進む
 - Step 8 の最終サマリに、各観点が検証を通過したかどうかを含める
 
 #### strategy: standard（デフォルト・bug + security の 2 並列）
@@ -389,7 +393,7 @@ git commit -m "refactor: self-review (simplify + review fixes)"
 以下の条件に 1 つでも該当したら、以降のステップをスキップして Step 8 へ直行する:
 
 - **`simple` strategy**（diff ≤ 30 行 かつ ファイル ≤ 3、`--force-external` なし）→ Step 3 を全スキップし、Simplify 結果のみで Step 6 → Step 8 へ
-- **`docs-only` strategy**（変更ファイルがすべて非コード）→ Step 1（Simplify）と Step 3（外部レビュー）を両方スキップし、司令塔の事実照合結果のみで Step 8 へ
+- **`docs-only` strategy**（変更ファイルがすべて非コード、`--force-external` なし）→ Step 1（Simplify）と Step 3（外部レビュー）を両方スキップし、司令塔の事実照合結果のみで Step 8 へ。**`--force-external` を指定したときは Step 3 を実行する**（Step 0 の戦略判定・Step 3 と同じ優先順位にそろえる。`--force-external` は「自動スキップを無視して外部レビューを回す」ための指定なので、docs-only でも同じ意味になる）。なお Simplify は `--force-external` の有無に関わらずスキップする（Markdown には作用対象が無いため）
 - 外部レビュー結果の findings が 0 件 かつ Simplify でも変更なし → 何もコミットせず終了
 - critical が 0 件 かつ judgment が 0 件 → judgment フェーズをスキップ（auto-fix のみ適用して Step 6 へ）
 

--- a/private_dot_claude/skills/self-review/docs/improvement-ideas.md
+++ b/private_dot_claude/skills/self-review/docs/improvement-ideas.md
@@ -286,3 +286,25 @@ fallback (primary が失敗した場合):
 **bug 観点**: `claude -p` の OAuth セッション切れで実行不可だったため今回はスキップ。Opus 自身を代替レビュアーとする経路は SKILL.md に未追加（次フェーズ検討課題）。
 
 **収穫**: セルフレビュー第 1 回で 7 件の仕様ミス + 設計上のセキュリティ問題 2 件を検知。「自分の改修を自分のスキルで検証する」ループが、新仕様の精度を急激に上げる効果が確認できた。
+
+---
+
+## 未実装: docs 変更向けの観点
+
+> Created: 2026-08-25 (JST)
+> Context: bug/security 観点の呼び出し経路の不具合修正（`fix/self-review-invocation-reliability`）で
+> `docs-only` strategy を追加した。Markdown のみの変更では bug/security の外部レビューを丸ごとスキップし、
+> 代わりに司令塔（セッションのメインモデル）が事実照合を行う運用にしたが、この事実照合を専用の観点として
+> スクリプト化する作業は今回の修正範囲外とし、見送った。
+
+`docs-only` のときに司令塔が確認すべき最低限の項目（SKILL.md の「strategy: docs-only」節と同一）:
+
+- 文書が参照している Issue 番号・Pull Request 番号が実在し、内容が食い違っていないか
+- 相対リンクの参照先が実在するか
+- Mermaid 図があれば構文が通るか（`~/.claude/docs/mermaid-conventions.md` の検証レシピ）
+- 記述している日付・固有名詞が事実と一致するか
+
+現状は司令塔が手動でこれらを確認する運用に留まる。将来的には、これらの項目を機械的にチェックする
+スクリプト（例: Issue/PR 番号の存在確認は `gh issue view` / `gh pr view` の exit code で、相対リンクの
+存在確認はファイルシステム走査で自動化できる）を追加し、`docs-only` strategy 専用のレビュアーとして
+Step 3 に組み込むことを検討する。

--- a/private_dot_claude/skills/self-review/references/review-prompts.md
+++ b/private_dot_claude/skills/self-review/references/review-prompts.md
@@ -144,18 +144,42 @@ SCHEMA="${CLAUDE_SKILL_DIR}/references/schemas/finding-schema.json"
 ATTACHED=$(...上記の対象ファイル添付ブロックを生成...)
 PROMPT=$(build_prompt "$ASPECT" "$ATTACHED")  # 「観点別プロンプトの組み立て」節参照
 
-echo "$DIFF" | claude -p \
+# claude -p の --json-schema は $schema キー付きスキーマを拒否する
+# （エラー: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"）。
+# finding-schema.json 自体は変更せず、claude -p に渡す直前だけ jq で $schema を取り除く。
+CLAUDE_SCHEMA=$(mktemp "${TMPDIR:-/tmp}/self-review-schema.XXXXXX")
+jq 'del(."$schema")' "$SCHEMA" > "$CLAUDE_SCHEMA"
+trap 'rm -f "$CLAUDE_SCHEMA"' EXIT
+
+# クロスプラットフォーム timeout ラッパー（macOS に timeout コマンドは無いため必須）
+source "${CLAUDE_SKILL_DIR}/scripts/lib-timeout.sh"
+
+OUT=$(mktemp "${TMPDIR:-/tmp}/self-review-bug.XXXXXX.json")
+echo "$DIFF" | _timeout 120 claude -p \
   $BARE_CLAUDE \
   --model sonnet \
   --output-format json \
-  --json-schema "$(cat "$SCHEMA")" \
+  --json-schema "$(cat "$CLAUDE_SCHEMA")" \
   --permission-mode dontAsk \
   --allowedTools "Read" \
-  --append-system-prompt "あなたは ${ASPECT} 観点に特化したコードレビュアーです。$PROMPT"
+  --append-system-prompt "あなたは ${ASPECT} 観点に特化したコードレビュアーです。$PROMPT" \
+  > "$OUT"
+
+# 出力の検証・正規化（「共通: レビュアー出力の検証」節参照）。
+# 通過していない出力を「指摘 0 件」と解釈してはならない。失敗したら fallback へ。
+if NORMALIZED=$(bash "${CLAUDE_SKILL_DIR}/scripts/validate-findings.sh" "$OUT"); then
+  : # $NORMALIZED を採用
+else
+  : # 検証失敗。fallback（Codex → Gemini）へ
+fi
 ```
 
 `$BARE_CLAUDE` は Step 0 で `ANTHROPIC_API_KEY` が設定済みのとき `--bare`、未設定なら空文字に設定される。
-`--json-schema` は **schema ファイルの中身（JSON 文字列）** を渡すフラグであり、ファイルパスではない点に注意（`$(cat "$SCHEMA")` で展開する）。
+`--json-schema` は **schema ファイルの中身（JSON 文字列）** を渡すフラグであり、ファイルパスではない点に注意（`$(cat "$CLAUDE_SCHEMA")` で展開する）。
+
+**他の `claude -p` 呼び出し例（design / macro goal-achievement 等）も同じ 3 点（$schema 除去 /
+`_timeout` ラップ / `validate-findings.sh` 検証）を適用すること**。以降の呼び出し例では重複を避けて
+`--json-schema "$(cat "$SCHEMA")"` の簡略表記のままにしているが、実行時は上のブロックと同じ手順を踏む。
 
 ### 呼び出し例（bug 観点を ultrareview に投げる、`--ultrareview` 時）
 
@@ -197,7 +221,15 @@ PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/self-review-prompt.XXXXXX.md")
 trap 'rm -f "$PROMPT_FILE"' EXIT
 echo "$PROMPT_BODY" > "$PROMPT_FILE"
 
-echo "$DIFF" | bash "${CLAUDE_SKILL_DIR}/scripts/codex-review.sh" "$SCHEMA" "$PROMPT_FILE"
+OUT=$(mktemp "${TMPDIR:-/tmp}/self-review-security.XXXXXX.json")
+echo "$DIFF" | bash "${CLAUDE_SKILL_DIR}/scripts/codex-review.sh" "$SCHEMA" "$PROMPT_FILE" > "$OUT"
+
+# 出力の検証・正規化（「共通: レビュアー出力の検証」節参照）。
+if NORMALIZED=$(bash "${CLAUDE_SKILL_DIR}/scripts/validate-findings.sh" "$OUT"); then
+  : # $NORMALIZED を採用
+else
+  : # 検証失敗。fallback（Claude-p → Gemini）へ
+fi
 ```
 
 `scripts/codex-review.sh` の内部で `-c model_reasoning_effort=high` / `--output-schema` /
@@ -206,6 +238,30 @@ echo "$DIFF" | bash "${CLAUDE_SKILL_DIR}/scripts/codex-review.sh" "$SCHEMA" "$PR
 組み立てて `codex exec` を実行する。フラグの詳細はスクリプト本体のコメントを参照。
 
 `-c model_reasoning_effort=high` は外部レビューの effort を high に固定する。`--ignore-user-config` で `~/.codex/config.toml` を無視するため、effort を狙った値にするには `-c` 明示指定が必須。委譲パスのグローバル default は medium に下げてレートを節約しつつ、低頻度なセカンドオピニオンだけ high を選ぶメリハリ運用（委譲パスは config.toml を尊重するが、レビュー系は `--ignore-user-config` で読まない）。
+
+### 共通: レビュアー出力の検証（[scripts/validate-findings.sh](../scripts/validate-findings.sh)）
+
+シェルの終了コードが 0 でも、出力が空・壊れた JSON・スキーマ違反であることがある
+（primary レビュアーが起動直後にエラーで落ちても全体の終了コードは 0 のまま、というケースが実際に発生した）。
+**すべてのレビュアー呼び出しの直後**にこのスクリプトを通し、検証・正規化する。
+
+```
+Usage: validate-findings.sh <出力ファイルのパス>
+```
+
+- 標準出力: 検証を通過した場合、正規化した単一 JSON オブジェクト（`findings` 配列 + `summary`）
+- 標準エラー: 失敗理由（`[self-review] ` 接頭辞）
+- 終了コード: 0 = 通過 / 1 = 検証失敗
+
+検証を通過していない出力は**「指摘 0 件」と解釈してはならない**。失敗したレビュアーは「失敗」として扱い、
+fallback 順に次のレビュアーを試す。Step 8 の最終サマリには各観点が検証を通過したかどうかを含める。
+
+`claude -p` と `scripts/codex-review.sh` は出力の形が異なるため、`validate-findings.sh` が正規化する:
+
+| レビュアー | 出力構造 |
+|-----------|---------|
+| `claude -p --output-format json` | ラッパー形式。`.is_error`（失敗判定）/ `.subtype`（成功時 `"success"`）/ `.structured_output`（本体、findings + summary を持つ）/ `.result`（人間向けテキスト） |
+| `scripts/codex-review.sh` | `{"findings":[...],"summary":"..."}` を裸で返す（ラッパー無し） |
 
 ### 呼び出し例（design 観点を Claude-p に投げる、`--with-design` 時のデフォルト）
 

--- a/private_dot_claude/skills/self-review/references/review-prompts.md
+++ b/private_dot_claude/skills/self-review/references/review-prompts.md
@@ -134,7 +134,7 @@ Gemini は `--with-gemini` 指定時のみ経路に入る。
   - `codex >= 0.122` 環境では `--ignore-user-config --ignore-rules` もスクリプト内部の判定で追加する（旧 `$CODEX_REPRO_FLAGS`、判定ロジックは Step 0 からスクリプトへ移設済み）
   - モデルはスクリプトが `-c model=`（default: `gpt-5.6-terra`、環境変数 `CODEX_REVIEW_MODEL` で上書き可）で明示する。terra は `--output-schema` 順守を確認済み（2026-07-14）。`--model gpt-5` と旧既定 `gpt-5.3-codex` は ChatGPT アカウント認証だと 400 で拒否されるため使わない（2026-07 実測。5.6 系は影響なし）
   - レビュー指示は `--output-schema` 用プロンプト本文に「以下の diff をレビューせよ」と明示して埋め込む
-- **`claude ultrareview`**: `--json` を必須化。exit code 0=完了 / 1=失敗 / 130=Ctrl-C を尊重し、stdout のみパース対象とする
+- **`claude ultrareview`**: `--json` を必須化。exit code 0=完了 / 1=失敗 / 130=Ctrl-C を尊重し、stdout のみパース対象とする。**呼び出しは `scripts/lib-timeout.sh` の `_timeout` でラップする**（`claude -p` / `codex-review.sh` と同じ）。タイムアウトしたら bug 観点の fallback へ進む。正規化した出力は `validate-findings.sh` へ通す
 
 ### 呼び出し例（bug 観点を Claude-p に投げる、デフォルト）
 
@@ -188,19 +188,39 @@ fi
 # 一時ファイルは mktemp で衝突回避（CWE-377/379 対策）
 umask 077
 TMP=$(mktemp "${TMPDIR:-/tmp}/ultrareview.XXXXXX.json")
-trap 'rm -f "$TMP"' EXIT
+NORMALIZED_FILE=$(mktemp "${TMPDIR:-/tmp}/ultrareview-normalized.XXXXXX.json")
+trap 'rm -f "$TMP" "$NORMALIZED_FILE"' EXIT
 
-claude ultrareview --json > "$TMP"
+# 他のレビュアーと同じく _timeout でラップする。包まないと、CLI が応答しなくなったときに
+# レビュー全体がそこで止まり、fallback にも進めない。
+source "${CLAUDE_SKILL_DIR}/scripts/lib-timeout.sh"
+_timeout 600 claude ultrareview --json > "$TMP"
 RC=$?
 case $RC in
-  0) jq '.' "$TMP" ;;        # 成功: findings を整形
-  1) echo "ultrareview 失敗、claude -p にフォールバック" >&2 ;;
-  130) echo "Ctrl-C 中断" >&2 ;;
+  0) : ;;                    # 成功: 下の正規化と検証へ進む
+  1) echo "ultrareview 失敗、claude -p にフォールバック" >&2; exit 1 ;;
+  130) echo "Ctrl-C 中断" >&2; exit 130 ;;
+  *) echo "ultrareview がタイムアウト（または想定外の終了 $RC）、claude -p にフォールバック" >&2; exit 1 ;;
 esac
+
+# ultrareview の出力は finding-schema.json と完全には一致しないことがあるため、
+# aspect: bug / category / severity を補完する正規化をかける（下の注記を参照）。
+normalize_ultrareview "$TMP" > "$NORMALIZED_FILE"
+
+# 正規化した結果も、ほかのレビュアーと同じ検証ゲートを通す。
+if VALIDATED=$(bash "${CLAUDE_SKILL_DIR}/scripts/validate-findings.sh" "$NORMALIZED_FILE"); then
+  echo "$VALIDATED"
+else
+  echo "ultrareview の出力が検証を通らず、claude -p にフォールバック" >&2
+  exit 1
+fi
 ```
 
 ultrareview の出力は `finding-schema.json` と完全には一致しない可能性があるため、
-パース後に `aspect: bug` / `category` / `severity` を補完する正規化レイヤを通す。
+パース後に `aspect: bug` / `category` / `severity` を補完する正規化レイヤ
+（上の `normalize_ultrareview`）を通す。**正規化しただけで採用してはならない。**
+正規化した結果を `validate-findings.sh` へ通し、失敗したら fallback へ進む
+（ほかのレビュアーとまったく同じ扱いにする）。
 
 ### 呼び出し例（security 観点を Codex に投げる）
 
@@ -402,10 +422,15 @@ if [ -n "$ANTHROPIC_API_KEY" ]; then export BARE_CLAUDE="--bare"; else export BA
 umask 077
 TMP=$(mktemp "${TMPDIR:-/tmp}/ultrareview.XXXXXX.json")
 trap 'rm -f "$TMP"' EXIT
-claude ultrareview --json > "$TMP"
+source "${CLAUDE_SKILL_DIR}/scripts/lib-timeout.sh"
+_timeout 600 claude ultrareview --json > "$TMP"
 ```
 
 PR 番号や base branch も指定可（詳細は `claude ultrareview --help`）。
+
+`_timeout` で包むのは、CLI が応答しなくなったときにレビュー全体を止めないためである
+（`claude -p` / `codex-review.sh` と同じ扱い）。取得したあとの正規化と検証は
+「呼び出し例（bug 観点を ultrareview に投げる）」を参照する。
 
 ### 課金
 

--- a/private_dot_claude/skills/self-review/scripts/executable_codex-review.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_codex-review.sh
@@ -20,6 +20,9 @@
 #     400 invalid_request_error で拒否される（2026-07 実測。5.6 系は影響なし）。
 # - codex exec は git リポジトリ内（trusted directory）を cwd にして実行すること。
 #   リポジトリ外から呼ぶと "Not inside a trusted directory" で失敗する。
+# - codex exec の呼び出しは lib-timeout.sh の _timeout でラップする（macOS に timeout
+#   コマンドは無いため、素の timeout を直接使わないこと）。既定 300 秒、環境変数
+#   CODEX_REVIEW_TIMEOUT で上書き可能。
 #
 # Usage:
 #   cat <<'EOF' | bash codex-review.sh <schema-path> <prompt-body-file>
@@ -33,17 +36,27 @@
 # 標準入力:
 #   diff 本文（git diff の出力）
 #
+# 環境変数:
+#   CODEX_REVIEW_MODEL    codex exec に渡すモデル（default: gpt-5.6-terra）
+#   CODEX_REVIEW_TIMEOUT  codex exec のタイムアウト秒数（default: 300）
+#
 # 出力:
 #   stdout - codex の --output-last-message 内容（finding-schema.json 準拠 JSON を想定）
+#            codex exec 自身が最終メッセージを stdout にも書くため、そちらは /dev/null へ
+#            捨てて二重出力を防いでいる（本体は $TMP から cat する 1 回だけ）
 #   stderr - 進行ログ
 #
 # Exit codes:
 #   0 - 成功
-#   1 - 依存コマンド不足 / 引数不足 / codex 実行失敗
+#   1 - 依存コマンド不足 / 引数不足 / codex 実行失敗 / タイムアウト
 
 set -uo pipefail
 
+LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${LIB_DIR}/lib-timeout.sh"
+
 CODEX_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.6-terra}"
+CODEX_REVIEW_TIMEOUT="${CODEX_REVIEW_TIMEOUT:-300}"
 
 if ! command -v codex >/dev/null 2>&1; then
   >&2 echo "[self-review] codex CLI が見つかりません。security/design 観点は他レビュアーにフォールバックしてください"
@@ -96,16 +109,30 @@ trap 'rm -f "$TMP"' EXIT
   echo '```diff'
   cat -
   echo '```'
-} | codex exec \
+} | _timeout "$CODEX_REVIEW_TIMEOUT" codex exec \
   -c model="$CODEX_MODEL" \
   -c model_reasoning_effort=high \
   --output-schema "$SCHEMA" \
   --output-last-message "$TMP" \
   --sandbox read-only \
   ${CODEX_REPRO_FLAGS[@]+"${CODEX_REPRO_FLAGS[@]}"} \
-  -
+  - \
+  >/dev/null
+# codex exec は最終メッセージを自身の stdout にも書くため、ここで /dev/null へ捨てる。
+# 捨てないと --output-last-message ($TMP) の内容と合わせて同じ JSON が 2 回出力される
+# （呼び出し側の validate-findings.sh が「JSON オブジェクトが複数連結されています」で
+# 検出する不具合だった）。stderr は進行ログ・エラー診断に使うため捨てない。
 
 EXIT_CODE=$?
+
+# タイムアウト時の終了コードは _timeout がどの実装に落ちたかで変わる。
+#   GNU timeout / gtimeout → 124
+#   perl の alarm（timeout も gtimeout も無い macOS 標準環境）→ 142（128 + SIGALRM 14）
+# macOS では 142 になるため、124 だけを見るとタイムアウト分岐が死にコードになる。
+if [[ $EXIT_CODE -eq 124 || $EXIT_CODE -eq 142 ]]; then
+  >&2 echo "[self-review] Codex がタイムアウトしました（${CODEX_REVIEW_TIMEOUT}秒）"
+  exit 1
+fi
 
 if [[ $EXIT_CODE -ne 0 ]]; then
   >&2 echo "[self-review] Codex 実行失敗 (exit=$EXIT_CODE)"

--- a/private_dot_claude/skills/self-review/scripts/executable_gemini-preflight.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_gemini-preflight.sh
@@ -53,18 +53,10 @@ if ! command -v gemini >/dev/null 2>&1; then
   exit 1
 fi
 
-# クロスプラットフォーム timeout ラッパー
-# GNU timeout (Linux) / gtimeout (macOS coreutils) / perl alarm (macOS 標準) の順で試す
-_timeout() {
-  local dur="$1"; shift
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "$dur" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$dur" "$@"
-  else
-    perl -e 'my $d=shift; alarm $d; exec @ARGV or die "exec failed: $!"' "$dur" "$@"
-  fi
-}
+# クロスプラットフォーム timeout ラッパー（_timeout）は共有ライブラリから読み込む
+# （codex-review.sh でも同じ仕組みが必要になったため lib-timeout.sh へ切り出し済み）
+LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${LIB_DIR}/lib-timeout.sh"
 
 # 軽量プローブ: 1モデルに対して 1 ショットだけ投げる
 # return: 0 成功 / 2 容量不足 (429) / 1 その他エラー

--- a/private_dot_claude/skills/self-review/scripts/executable_lib-timeout.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_lib-timeout.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# 共有ライブラリ: クロスプラットフォーム timeout ラッパー。
+#
+# このファイルは単体実行するスクリプトではない。呼び出し元のスクリプトから
+# `source` して `_timeout` 関数だけを使う。
+#
+# Usage（呼び出し元スクリプトの先頭付近）:
+#   LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+#   source "${LIB_DIR}/lib-timeout.sh"
+#   _timeout 120 some-command --with args
+#
+# 実装: GNU timeout (Linux) → gtimeout (macOS coreutils) → perl の alarm (macOS 標準)
+# の順で試す。macOS には `timeout` コマンドが標準で存在しないため、呼び出し元は
+# 素の `timeout` を直接使わないこと（`command not found` で即死する）。
+#
+# 元々は scripts/gemini-preflight.sh に閉じて定義されていたが、Codex レビュー
+# （scripts/codex-review.sh）でも同じ仕組みが必要になったため、共有ライブラリへ
+# 切り出した。
+
+# 注意: このファイルは source される側なので、`set` でシェルオプションを変更しない。
+# 変更すると呼び出し元スクリプトの挙動を書き換えてしまう。
+
+_timeout() {
+  local dur="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$dur" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$dur" "$@"
+  else
+    perl -e 'my $d=shift; alarm $d; exec @ARGV or die "exec failed: $!"' "$dur" "$@"
+  fi
+}

--- a/private_dot_claude/skills/self-review/scripts/executable_validate-findings.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_validate-findings.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# self-review 用: 外部レビュアー出力の検証・正規化ゲート。
+#
+# 背景: claude -p / codex exec はシェルの終了コードが 0 でも、出力が空・壊れた
+# JSON・スキーマ違反であることがある。呼び出し側（司令塔）がこれを見分けずに
+# 「指摘 0 件」と誤報告する事故が起きたため、専用の検証ステップを設ける。
+# 検証を通過していない出力は「失敗」として扱い、fallback レビュアーへ進むこと。
+#
+# claude -p と codex exec（scripts/codex-review.sh）は出力の形が異なる:
+#   - claude -p --output-format json: ラッパー形式。
+#       .is_error / .subtype / .structured_output（本体） / .result（人間向けテキスト）
+#   - scripts/codex-review.sh: {"findings":[...], "summary":"..."} を裸で返す
+# 本スクリプトはこの差異を吸収し、どちらの形式でも同じ正規化済み JSON を返す。
+#
+# Usage:
+#   validate-findings.sh <出力ファイルのパス>
+#
+# 標準出力:
+#   検証を通過した場合、正規化した単一 JSON オブジェクト（findings 配列 + summary）
+#
+# 標準エラー:
+#   失敗理由（[self-review] 接頭辞）
+#
+# Exit codes:
+#   0 - 検証通過
+#   1 - 検証失敗
+
+set -uo pipefail
+
+FILE="${1:-}"
+
+if [[ -z "$FILE" ]]; then
+  >&2 echo "[self-review] Usage: validate-findings.sh <output-file-path>"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  >&2 echo "[self-review] jq が見つかりません"
+  exit 1
+fi
+
+# 1. ファイルが存在し、サイズが 0 でないこと
+if [[ ! -s "$FILE" ]]; then
+  >&2 echo "[self-review] レビュアーが出力を返しませんでした（ファイルが存在しないか空です）: $FILE"
+  exit 1
+fi
+
+# 2〜3. jq -s でスラープし、妥当な JSON か・オブジェクトが何個連結されているかを同時に見る
+#       （codex-review.sh が codex exec 自身の stdout 出力と --output-last-message の
+#       内容を両方吐いて JSON が 2 個連結される、といった二重出力を検出する）
+SLURPED=$(jq -s -c '.' "$FILE" 2>/dev/null)
+if [[ $? -ne 0 || -z "$SLURPED" ]]; then
+  >&2 echo "[self-review] 妥当な JSON としてパースできませんでした: $FILE"
+  exit 1
+fi
+
+COUNT=$(echo "$SLURPED" | jq 'length')
+
+if [[ "$COUNT" -eq 0 ]]; then
+  >&2 echo "[self-review] JSON オブジェクトが見つかりませんでした: $FILE"
+  exit 1
+fi
+
+if [[ "$COUNT" -gt 1 ]]; then
+  >&2 echo "[self-review] JSON オブジェクトが複数連結されています（${COUNT} 個）。レビュアー呼び出し側の二重出力を疑ってください: $FILE"
+  exit 1
+fi
+
+RAW=$(echo "$SLURPED" | jq -c '.[0]')
+
+# 4. 形を判定して正規化する
+#    claude -p のラッパー形式は is_error キーの有無で見分ける（.structured_output の型では
+#    見分けない。エラー時は structured_output が null になり得るため、型だけで判定すると
+#    is_error: true の実エラーを「findings を含む JSON ではありません」に誤分類してしまう）。
+IS_WRAPPER=$(echo "$RAW" | jq -c 'has("is_error")' 2>/dev/null)
+HAS_TOPLEVEL_FINDINGS=$(echo "$RAW" | jq -c '(.findings? | type) == "array"' 2>/dev/null)
+
+if [[ "$IS_WRAPPER" == "true" ]]; then
+  # claude -p のラッパー形式
+  # 5. is_error が true なら失敗として扱う（理由に .result の先頭 200 文字を添える）
+  IS_ERROR=$(echo "$RAW" | jq -r '.is_error // false')
+  if [[ "$IS_ERROR" == "true" ]]; then
+    RESULT_HEAD=$(echo "$RAW" | jq -r '.result // ""' | cut -c1-200)
+    >&2 echo "[self-review] claude -p がエラーを返しました（is_error: true）: ${RESULT_HEAD}"
+    exit 1
+  fi
+  # structured_output が無い/オブジェクトでない異常系は、下の findings 配列チェック（手順 6）で捕捉する
+  NORMALIZED=$(echo "$RAW" | jq -c '.structured_output')
+elif [[ "$HAS_TOPLEVEL_FINDINGS" == "true" ]]; then
+  # Codex 形式（トップレベルに findings をそのまま持つ）
+  NORMALIZED="$RAW"
+else
+  >&2 echo "[self-review] findings を含む JSON ではありません（claude -p の structured_output も、トップレベルの findings 配列も見つかりません）: $FILE"
+  exit 1
+fi
+
+# 6. 採用したオブジェクトの .findings が配列であることを確認する
+FINDINGS_IS_ARRAY=$(echo "$NORMALIZED" | jq -c '(.findings? | type) == "array"' 2>/dev/null)
+if [[ "$FINDINGS_IS_ARRAY" != "true" ]]; then
+  >&2 echo "[self-review] findings が配列ではありません: $FILE"
+  exit 1
+fi
+
+echo "$NORMALIZED"
+exit 0

--- a/private_dot_claude/skills/self-review/scripts/executable_validate-findings.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_validate-findings.sh
@@ -102,12 +102,18 @@ fi
 # 通すと、後段の集計や auto-fix の判定が静かに壊れる。ここで弾いて fallback へ回す。
 #
 # jq でスキーマ全体を厳密に検証するのは大掛かりになるため、finding-schema.json の
-# required と enum だけを写して確認する。スキーマを変えたときは、ここも合わせて直す。
+# 制約を写して確認する。確認するのは required / enum / line の integer と minimum 0 /
+# suggestion の string または null / 両階層の additionalProperties: false の 5 つである。
+# スキーマを変えたときは、ここも合わせて直す。
 if ! SCHEMA_ERRORS=$(echo "$NORMALIZED" | jq -r '
   def required_keys: ["severity","category","aspect","file","line","title","description","suggestion"];
+  def root_keys: ["findings","summary"];
   [
     (if (.findings | type) != "array" then "findings が配列ではありません" else empty end),
-    (if (.summary | type) != "string" then "summary が文字列ではありません" else empty end)
+    (if (.summary | type) != "string" then "summary が文字列ではありません" else empty end),
+    (if ((keys - root_keys) | length) > 0 then
+       "トップレベルに未知のキーがあります: " + ((keys - root_keys) | join(", "))
+     else empty end)
   ]
   + (
     if (.findings | type) == "array" then
@@ -119,14 +125,18 @@ if ! SCHEMA_ERRORS=$(echo "$NORMALIZED" | jq -r '
             $at + " がオブジェクトではありません"
           elif ((required_keys - ($f | keys)) | length) > 0 then
             $at + " に必須フィールドがありません: " + ((required_keys - ($f | keys)) | join(", "))
+          elif ((($f | keys) - required_keys) | length) > 0 then
+            $at + " に未知のキーがあります: " + ((($f | keys) - required_keys) | join(", "))
           elif (["critical","warning","info"] | index($f.severity)) == null then
             $at + ".severity が enum 外です"
           elif (["auto-fix","judgment","info"] | index($f.category)) == null then
             $at + ".category が enum 外です"
           elif (["bug","security","design","goal-achievement","spec-consistency","all"] | index($f.aspect)) == null then
             $at + ".aspect が enum 外です"
-          elif ($f.line | type) != "number" then
-            $at + ".line が数値ではありません"
+          elif ($f.line | type) != "number" or ($f.line | floor) != $f.line or $f.line < 0 then
+            $at + ".line が 0 以上の整数ではありません"
+          elif ((($f.suggestion | type) == "string" or ($f.suggestion | type) == "null") | not) then
+            $at + ".suggestion が文字列でも null でもありません"
           elif ([$f.file, $f.title, $f.description] | any(.[]; type != "string")) then
             $at + " の file / title / description に文字列でない値があります"
           else empty

--- a/private_dot_claude/skills/self-review/scripts/executable_validate-findings.sh
+++ b/private_dot_claude/skills/self-review/scripts/executable_validate-findings.sh
@@ -94,10 +94,56 @@ else
   exit 1
 fi
 
-# 6. 採用したオブジェクトの .findings が配列であることを確認する
-FINDINGS_IS_ARRAY=$(echo "$NORMALIZED" | jq -c '(.findings? | type) == "array"' 2>/dev/null)
-if [[ "$FINDINGS_IS_ARRAY" != "true" ]]; then
-  >&2 echo "[self-review] findings が配列ではありません: $FILE"
+# 6. 採用したオブジェクトを finding-schema.json の必須構造と突き合わせる
+#
+# 以前は「.findings が配列か」だけを見ていた。それだと {"findings":[{}]} や、summary の
+# 無い {"findings":[]} が検証を通り抜けてしまう。severity / category / aspect は呼び出し元が
+# そのまま信頼して分類に使うため（finding-schema.json の説明を参照）、enum から外れた値を
+# 通すと、後段の集計や auto-fix の判定が静かに壊れる。ここで弾いて fallback へ回す。
+#
+# jq でスキーマ全体を厳密に検証するのは大掛かりになるため、finding-schema.json の
+# required と enum だけを写して確認する。スキーマを変えたときは、ここも合わせて直す。
+if ! SCHEMA_ERRORS=$(echo "$NORMALIZED" | jq -r '
+  def required_keys: ["severity","category","aspect","file","line","title","description","suggestion"];
+  [
+    (if (.findings | type) != "array" then "findings が配列ではありません" else empty end),
+    (if (.summary | type) != "string" then "summary が文字列ではありません" else empty end)
+  ]
+  + (
+    if (.findings | type) == "array" then
+      [ .findings
+        | to_entries[]
+        | ("findings[" + (.key | tostring) + "]") as $at
+        | .value as $f
+        | if ($f | type) != "object" then
+            $at + " がオブジェクトではありません"
+          elif ((required_keys - ($f | keys)) | length) > 0 then
+            $at + " に必須フィールドがありません: " + ((required_keys - ($f | keys)) | join(", "))
+          elif (["critical","warning","info"] | index($f.severity)) == null then
+            $at + ".severity が enum 外です"
+          elif (["auto-fix","judgment","info"] | index($f.category)) == null then
+            $at + ".category が enum 外です"
+          elif (["bug","security","design","goal-achievement","spec-consistency","all"] | index($f.aspect)) == null then
+            $at + ".aspect が enum 外です"
+          elif ($f.line | type) != "number" then
+            $at + ".line が数値ではありません"
+          elif ([$f.file, $f.title, $f.description] | any(.[]; type != "string")) then
+            $at + " の file / title / description に文字列でない値があります"
+          else empty
+          end
+      ]
+    else [] end
+  )
+  | join(" / ")
+' 2>/dev/null); then
+  >&2 echo "[self-review] findings の検証中に jq がエラーを返しました: $FILE"
+  exit 1
+fi
+
+if [[ -n "$SCHEMA_ERRORS" ]]; then
+  # ${FILE} を波括弧で囲むのは、直後の全角括弧を bash が変数名の一部として読んでしまい
+  # "FILE）: unbound variable" で落ちるため（この修正の動作確認で実際に踏んだ）。
+  >&2 echo "[self-review] findings がスキーマに合致しません（${FILE}）: $SCHEMA_ERRORS"
   exit 1
 fi
 


### PR DESCRIPTION
## 概要

`self-review` スキルの呼び出し経路にある不具合 6 件を直す。**一番の問題は「レビューが失敗しているのに指摘 0 件に見える」ことだった。**

2026-08-25 に artifact-gate の Pull Request でこのスキルを実行したところ、次が起きた。

1. bug 観点の一次レビュアー（`claude -p`）が起動直後にエラーで落ちた
2. タイムアウトを付けようとしたら macOS で `command not found` になり、これも起動しなかった
3. **どちらもシェル全体の終了コードは 0** で、出力が 0 バイトなのに「完了」と表示された。危うく「指摘 0 件で問題なし」と報告するところだった
4. Codex 側のレビュー出力は、同じ JSON が 2 回出ていた

## 直した内容

### 1. bug 観点の一次レビュアーが構造的に必ず失敗していた

同梱の `references/schemas/finding-schema.json` の先頭に `$schema` キーがある。`claude -p --json-schema` はこれを拒否する。

```
Error: --json-schema is not a valid JSON Schema: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

呼び出し例がスキーマをそのまま渡す形だったため、**bug 観点は毎回この時点で落ちていた**。`finding-schema.json` 自体は変更せず（Codex の `--output-schema` は `$schema` があっても動くため）、`claude -p` へ渡す直前だけ `jq 'del(."$schema")'` で除去する形にした。

### 2. レビュアー出力の検証ゲートを新設した

`scripts/validate-findings.sh` を追加し、**すべてのレビュアー呼び出しの直後に通す**ことを手順に加えた。次を検出して弾く。

- 出力が空
- 妥当な JSON としてパースできない
- JSON オブジェクトが複数連結されている（下の 4 のような二重出力）
- `claude -p` が `is_error: true` を返している
- `findings` が配列でない

あわせて、**2 つのレビュアーで出力の形が違う**のに正規化の手順が無かった点も直した。`claude -p` は `.structured_output` に本体を入れたラッパーを返し、`scripts/codex-review.sh` は裸のオブジェクトを返す。この差異は今までスキルのどこにも書かれていなかった。

**検証を通過していない出力を「指摘 0 件」と解釈してはならない**ことを明記した。

### 3. タイムアウトの仕組みが macOS で動かなかった

`SKILL.md` は「120 秒タイムアウトで次のレビュアーへ」と書いていたが、仕組みが定義されていなかった。macOS に `timeout` コマンドは無い。

一方、`scripts/gemini-preflight.sh` の中には移植可能な `_timeout()`（GNU `timeout` → `gtimeout` → perl の alarm）が既にあった。**Gemini 専用に閉じていたのが問題**だったので、`scripts/lib-timeout.sh` へ切り出し、Codex レビューと `claude -p` の呼び出し例からも使う形にした。

なお、**perl の alarm 経路はタイムアウト時に 142（128 + SIGALRM）を返す**。GNU `timeout` の 124 だけを見ているとこの環境では分岐が死ぬため、両方を受けるようにした（実測で確認）。

### 4. `codex-review.sh` が同じ JSON を 2 回出力していた

`codex exec` 自身が最終メッセージを標準出力へ書くのに、スクリプトが一時ファイルを重ねて `cat` していた。`codex exec` の標準出力を捨て、出力を 1 回だけにした。標準エラーは診断に使うため残している。

### 5. 変更の中身を見ずに外部レビューを呼んでいた

strategy の自動判定が diff の行数とファイル数しか見ていなかった。Markdown 2 ファイル・85 行の変更が `standard` と判定され、bug と security を呼んだが、両方とも「実行コードを含まないため対象が存在しない」と返した。外部呼び出し 2 回が空振りだった。

`docs-only` strategy を追加した。変更ファイルがすべて非コード（`.md` / `.markdown` / `.txt` / `.rst` / `.adoc`、または `docs/` 配下）なら、Simplify と外部レビューを両方スキップする。

ただし「レビューを飛ばして問題なしで終える」のは危険なので、**代わりに司令塔が事実照合を行う**手順を明記した。参照している Issue 番号と Pull Request 番号の実在、相対リンクの参照先、Mermaid の構文、日付と固有名詞の一致を確認する。

この事実照合を専用の観点としてスクリプト化するのは今回の範囲外とし、`docs/improvement-ideas.md` に未実装として記録した。

## テスト計画

すべて実機で確認済み。

### 検証ゲート（`validate-findings.sh`）— 6 ケース

| 入力 | 期待 | 結果 |
| --- | --- | --- |
| 空ファイル | 失敗 | 「出力を返しませんでした」 |
| Codex 形式の裸オブジェクト | 通過 | 正規化して出力 |
| `is_error: true` のラッパー | 失敗 | `.result` の先頭を添えて報告 |
| `findings` が配列でない | 失敗 | 「findings を含む JSON ではありません」 |
| **修正前の実データ**（JSON が 2 個連結） | 失敗 | 「複数連結されています（2 個）」 |
| **修正前の実データ**（正常なラッパー） | 通過 | 正規化して出力 |

### タイムアウト（`lib-timeout.sh`）

- `_timeout 5 echo hello` → 正常終了（0）
- `_timeout 1 sleep 5` → 1 秒で打ち切り、142 を返す（この環境は `timeout` も `gtimeout` も無く perl 経路）

### 修正前後の比較（実際の呼び出し）

| 項目 | 修正前 | 修正後 |
| --- | --- | --- |
| `claude -p` の bug 観点 | 0 バイト・スキーマエラーで即死 | 2539 バイトを返し、検証ゲートを通過 |
| `codex-review.sh` の出力 | JSON オブジェクト 2 個 | 1 個。検証ゲートを通過 |

### 構文チェック

`scripts/` 配下のシェルスクリプト 5 本すべて `bash -n` 通過。

### 適用の安全確認

`chezmoi apply` は `~/.claude/skills/self-review` に範囲を限定して実行した。適用後に `chezmoi status` を確認し、別ブランチで進行中の 4 ファイル（`.claude/CLAUDE.md` / `.claude/docs/chezmoi-workflow.md` / `.claude/settings.json` / `.claude/skills/skill-improve/SKILL.md`）が巻き戻っていないことを確認済み。

## 変更していないもの

- `references/schemas/finding-schema.json`（Codex の `--output-schema` は `$schema` があっても正常に動くため）
- `scripts/gemini-preflight.sh` の外部から見た振る舞い（標準出力に `available` / `flash-only` / `unavailable` / `disabled` を出す）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ドキュメントのみの変更に適したレビュー手順を追加し、Issue・リンク・Mermaid記法・事実情報を確認できるようにしました。
  * 外部レビューの実行時間を制御し、処理が長時間停止する問題を防止しました。
  * レビュー結果の形式を検証・統一し、不正な出力時は代替処理へ切り替えるよう改善しました。
  * 必要に応じて、ドキュメントのみの変更でも外部レビューを実行できるようにしました。
  * レビュー終了理由を最終サマリーに表示するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->