### PR TITLE
fix: Codex CLI 0.153.4 更新に伴うレビュースクリプトと文書の追従

### DIFF
--- a/dot_codex/config.seed.toml
+++ b/dot_codex/config.seed.toml
@@ -15,6 +15,7 @@
 # 既定モデルと reasoning effort。Claude Code からの委譲では毎回 --model / --effort を明示するため、
 # ここの値が効くのは明示指定を忘れた呼び出しだけ（指定漏れ時の保険）。
 # 既定は GPT-5.6 系のバランス型 terra（サブスク認証で動作確認済み）。
+# GPT-6 Astra（gpt-6-astra）は既定にしない。明示指定でのみ使う。
 # 消費の目安は「sol は terra の約 2 倍、luna は約 10 分の 1」。
 # 依頼内容ごとのモデルと effort の選び方は、Claude Code 側のルーティング表
 # （~/.claude/skills/task-delegation/references/codex-routing.md）が正本。

--- a/private_dot_claude/docs/codex-config.md
+++ b/private_dot_claude/docs/codex-config.md
@@ -90,7 +90,7 @@ Codex は Claude Code の拡張機構に 1:1 対応する仕組みを公式に�
 
 2026-07-09 に GPT-5.6 が登場し、Codex で `sol` / `terra` / `luna` の 3 モデルが使える。
 **ChatGPT サブスク認証（`auth_mode = chatgpt`）でも 3 モデルすべて使える**ことを 2026-07-14 に
-実挙動で確認した（Codex CLI v0.144.4・Codex.app build 26.707.72221）。
+実挙動で確認し、2026-09-08 に Codex CLI 0.153.4 で再確認した。
 
 - **既定は `gpt-5.6-terra`**（バランス型）。委譲パスの常用モデル。
 - **`gpt-5.6-sol`**（旗艦）は既定にしない。やり直しが高くつく作業だけ、都度 `--model gpt-5.6-sol` で指定する（判定基準の定義は `codex-routing.md`）。
@@ -110,10 +110,11 @@ Codex は Claude Code の拡張機構に 1:1 対応する仕組みを公式に�
 | `gpt-5.6-terra` | `low`〜`ultra` | `low`〜`xhigh` |
 | `gpt-5.6-luna` | `low`〜`max` | `low`〜`xhigh` |
 | `gpt-5.3-codex-spark` | `low`〜`xhigh` | `low`〜`xhigh` |
+| `gpt-6-astra` | `low`〜`max` | `low`〜`xhigh` |
 
 右の列は、モデルとプラグインの両方が受け付ける範囲である。`none` と `minimal` はプラグインの検証を通るが、モデル一覧に記載が無いため範囲から外してある。
 
-出典は実機の `~/.codex/models_cache.json`（利用可能モデルの一覧。Codex CLI 0.150.0・2026-09-03 取得）と、Codex プラグインの `scripts/codex-companion.mjs` 内の `VALID_REASONING_EFFORTS`。
+出典は実機の `~/.codex/models_cache.json`（利用可能モデルの一覧。Codex CLI 0.153.4・2026-09-08 取得。モデル一覧には `gpt-6-astra` が加わった）と、Codex プラグインの `scripts/codex-companion.mjs` 内の `VALID_REASONING_EFFORTS`。
 
 ### 履歴の訂正（重要）
 
@@ -129,11 +130,17 @@ sol 不可」は現在は誤り。過去に ChatGPT 認証で 400 になった `
 |---|---|---|
 | `config.toml` / `config.seed.toml` の `model` / `model_reasoning_effort` | `gpt-5.6-terra` / `medium` | 指定漏れ時の保険 |
 | self-review `scripts/codex-review.sh` | `-c model=`（default `gpt-5.6-terra`、`CODEX_REVIEW_MODEL` で上書き可） | `--output-schema` 順守を実挙動で確認済み（2026-07-14）。terra を既定として使用 |
-| peer-review `scripts/codex-review.sh` | model 未指定 + `--ignore-user-config` | codex 組み込み既定に追従（＝バージョンで漂う）。決定論が要るなら `-c model=gpt-5.6-sol` を検討 |
+| peer-review `scripts/codex-review.sh` | `-c model=` で明示（既定 `gpt-5.6-terra`。環境変数 `CODEX_REVIEW_MODEL` で上書き） | 0.153.4 からモデル未指定時の Codex 組み込み既定が `gpt-6-astra` になったため |
 | codex-imagegen | `gpt-image-2`（画像モデル） | テキストモデルとは別領域。対象外 |
 
 - 実機の `~/.codex/config.toml` は `gpt-5.6-sol` / `high` へずれていた。2026-09-04 に seed の値（`gpt-5.6-terra` / `medium`）へ戻した。
 - Claude Code は委譲時にモデルと effort を毎回明示する。よって `config.toml` の値は指定漏れ時の保険と位置づける。
+
+### CLI を更新したときの注意
+
+- Codex CLI 0.147.0 で `codex exec --full-auto` は削除された。代替は `--sandbox workspace-write` であり、review-doc と review-adr のスクリプトからは外した。
+- Codex CLI 0.150.0 から、`[projects]` で信頼していないディレクトリでは、そのリポジトリの `AGENTS.md` を読まない。新しいリポジトリへ委譲する前に、`config.toml` の `[projects]` に登録されているかを確認する。
+- Codex プラグインは Claude Code セッションごとに `codex app-server` を常駐させる。CLI を更新しても、更新前に起動したセッションは古いバイナリを使い続けるため、更新後は Claude Code セッションを立ち上げ直す。
 
 ## reasoning effort 制御マップ
 

--- a/private_dot_claude/skills/peer-review/scripts/executable_codex-review.sh
+++ b/private_dot_claude/skills/peer-review/scripts/executable_codex-review.sh
@@ -22,11 +22,14 @@
 #   - `--base` と PROMPT は併用不可（codex CLI の引数排他）。よって PROMPT は渡さず、
 #     codex review の標準観点に任せる。プロジェクト固有のコンテキストは L1 Claude 側で扱う
 #   - `--ignore-user-config --ignore-rules` でユーザー設定の差異を排除
+#   - `CODEX_REVIEW_MODEL` でレビューに使うモデルを変更可能（default: gpt-5.6-terra）
 #   - `--json` で JSONL 出力。最終 `agent_message` を jq で抽出
 #   - `-o <file>` の `output-last-message` は agent_message が空の場合も発生するため、
 #     JSONL 側の抽出を primary、`-o` ファイルを fallback とする
 
 set -uo pipefail
+
+CODEX_MODEL="${CODEX_REVIEW_MODEL:-gpt-5.6-terra}"
 
 # 依存確認
 if ! command -v jq >/dev/null 2>&1; then
@@ -69,11 +72,15 @@ trap 'rm -f "$JSONL_FILE" "$LAST_FILE"' EXIT
 >&2 echo "[peer-review] Codex review 実行中 (base=$BASE_BRANCH)..."
 
 # Codex を非対話で実行。PROMPT は渡さない（--base と排他のため）
+# -c model= はレビュー用モデルを明示する。--ignore-user-config で config.toml を無視するため、
+#   モデル未指定だと Codex CLI の組み込み既定に落ちる。0.153.4 では既定が gpt-6-astra
+#   （高額モデル）になったため、明示指定が必要になる。
 # -c model_reasoning_effort=high: L2 セカンドオピニオンは質が命なので effort を high に固定する。
 #   --ignore-user-config で config.toml を無視するため、-c 明示指定で effort を上書きする
 #   （委譲パスのグローバル default は medium に下げてレートを節約しているが、低頻度な
 #    レビューだけは high を選ぶメリハリ運用）
 codex exec review \
+  -c model="$CODEX_MODEL" \
   -c model_reasoning_effort=high \
   --base "$BASE_BRANCH" \
   --json \

--- a/private_dot_claude/skills/review-adr/SKILL.md
+++ b/private_dot_claude/skills/review-adr/SKILL.md
@@ -125,7 +125,7 @@ done
 bash "${CLAUDE_SKILL_DIR}/scripts/codex-review.sh" <プロンプトファイルのパス> /tmp/review-adr-codex.txt
 ```
 
-`scripts/codex-review.sh` の内部で `--full-auto` / `--sandbox read-only` / `--ignore-user-config` /
+`scripts/codex-review.sh` の内部で `--sandbox read-only` / `--ignore-user-config` /
 `--ignore-rules` / `--output-last-message` を組み立てて `codex exec` を実行する。
 
 `--with-gemini` 指定時のみ、`references/adr-prompt.md` を使って Gemini を追加実行する（opt-in）。

--- a/private_dot_claude/skills/review-adr/scripts/executable_codex-review.sh
+++ b/private_dot_claude/skills/review-adr/scripts/executable_codex-review.sh
@@ -45,7 +45,6 @@ fi
 >&2 echo "[review-adr] Codex レビュー実行中..."
 
 codex exec \
-  --full-auto \
   --sandbox read-only \
   --ignore-user-config \
   --ignore-rules \

--- a/private_dot_claude/skills/review-doc/SKILL.md
+++ b/private_dot_claude/skills/review-doc/SKILL.md
@@ -133,7 +133,7 @@ PR 専用（`codex exec review --base <branch>`）のため流用せず、review
 bash "${CLAUDE_SKILL_DIR}/scripts/codex-review.sh" <プロンプトファイルのパス> /tmp/review-doc-codex.txt
 ```
 
-`scripts/codex-review.sh` の内部で `--full-auto` / `--sandbox read-only` / `--ignore-user-config` /
+`scripts/codex-review.sh` の内部で `--sandbox read-only` / `--ignore-user-config` /
 `--ignore-rules` / `--output-last-message` を組み立てて `codex exec` を実行する。
 
 `--with-gemini` 指定時のみ、Gemini を追加で実行する（opt-in）。Gemini が失敗しても Codex/L1 の経路で続行する。

--- a/private_dot_claude/skills/review-doc/scripts/executable_codex-review.sh
+++ b/private_dot_claude/skills/review-doc/scripts/executable_codex-review.sh
@@ -47,7 +47,6 @@ fi
 >&2 echo "[review-doc] Codex レビュー実行中..."
 
 codex exec \
-  --full-auto \
   --sandbox read-only \
   --ignore-user-config \
   --ignore-rules \

--- a/private_dot_claude/skills/task-delegation/references/codex-routing.md
+++ b/private_dot_claude/skills/task-delegation/references/codex-routing.md
@@ -99,8 +99,9 @@ graph TD
 ### モデルを指定するときの注意
 
 - モデル ID はフル ID で指定します。Codex プラグインが解釈するエイリアスは `spark` の 1 つだけです。
-- Codex で使う文脈の広さは、`gpt-5.3-codex-spark` が 128k、他のモデルが 272k です（API の長文脈設定はこれと別枠）。大きな文脈を渡す依頼に `gpt-5.3-codex-spark` は使いません。
+- Codex で使う文脈の広さは、`gpt-5.3-codex-spark` が 128k、GPT-5.6 系が 272k です（API の長文脈設定はこれと別枠）。大きな文脈を渡す依頼に `gpt-5.3-codex-spark` は使いません。
 - 前世代の `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` は、再現性の検証で世代を固定したいとき以外は使いません。
+- **GPT-6 Astra（`gpt-6-astra`）**は、2026-09-03 に公開された最上位モデルです。文脈は 1.05M トークンで、effort は `low`〜`max` に対応します。プラグイン経由では `xhigh` までです。単価は 100 万トークンあたり入力 10 ドル、出力 50 ドルで、`gpt-5.6-sol` の約 2.5 倍です。既定のルーティングには入れず、ユーザーが明示して指示したときだけ使います。
 
 ## 第 2 軸: effort を上げ下げする
 
@@ -184,6 +185,7 @@ API の単価（100 万トークンあたりのドル。短い文脈の場合。
 
 | モデル | 入力 | 出力 |
 |---|---|---|
+| `gpt-6-astra` | 10 | 50 |
 | `gpt-5.6-sol` | 4 | 20 |
 | `gpt-5.6-terra` | 2 | 12 |
 | `gpt-5.6-luna` | 0.20 | 1.20 |
@@ -205,9 +207,10 @@ API の単価（100 万トークンあたりのドル。短い文脈の場合。
 
 ## 出典
 
-- モデル一覧・各モデルの既定 effort・対応する effort の段・文脈長: 実機の `~/.codex/models_cache.json`（利用可能モデルの一覧。Codex CLI 0.150.0、2026-09-03 取得）
-- プラグインが受け付ける effort とモデルのエイリアス: Codex プラグインの `scripts/codex-companion.mjs`（`VALID_REASONING_EFFORTS` と `MODEL_ALIASES`。v1.0.4）
+- モデル一覧・各モデルの既定 effort・対応する effort の段・文脈長: 実機の `~/.codex/models_cache.json`（利用可能モデルの一覧。Codex CLI 0.153.4、2026-09-08 取得）
+- プラグインが受け付ける effort とモデルのエイリアス: Codex プラグインの `scripts/codex-companion.mjs`（`VALID_REASONING_EFFORTS` と `MODEL_ALIASES`。v1.0.6。許容 effort は前版と同じ）
 - 「モデルと effort はユーザーが明示しない限り指定しない」: 同プラグインの `agents/codex-rescue.md`
 - `medium` を出発点にする推奨、effort 各段の使いどき、API での `gpt-5.6` が `gpt-5.6-sol` を指すこと: OpenAI Model guidance <https://developers.openai.com/api/docs/guides/latest-model>（2026-09-04 参照）
 - 3 モデルの位置づけ: GPT-5.6 の発表 <https://openai.com/index/gpt-5-6/>（2026-09-04 参照）
+- GPT-6 Astra の位置づけと API モデル情報: OpenAI の発表 <https://openai.com/index/gpt-6-astra/>、API モデルページ <https://developers.openai.com/api/docs/models/gpt-6-astra>（2026-09-08 参照）
 - API の単価と `gpt-5.6-sol` の期間限定価格: OpenAI の料金表 <https://developers.openai.com/api/docs/pricing>（2026-09-04 参照）


### PR DESCRIPTION
## 概要

2026-09-08 に Codex CLI を 0.145.0-alpha.23 から 0.153.4 へ更新した。GPT-6 Astra（`gpt-6-astra`）を使えるようにするための更新だが、その間のリリースに追従が必要な変更が 2 点あったので、この PR で対応する。

- **`codex exec --full-auto` の削除（0.147.0）**: ドキュメントレビュー（review-doc）と ADR レビュー（review-adr）のスクリプトが使っていた。実行すると引数エラーで落ちるため、フラグを外した。`--sandbox read-only` は残している。
- **モデル未指定時の既定が Astra になる（0.153.4）**: 他者 PR をレビューする peer-review のスクリプトは `--ignore-user-config` で設定ファイルを無視し、モデルも指定していなかった。そのままだと高額な Astra で走るため、`-c model=` を明示した（既定 `gpt-5.6-terra`、環境変数 `CODEX_REVIEW_MODEL` で上書き可）。

あわせて、Codex 設定の正本（`codex-config.md`）とモデル選択表（`codex-routing.md`）の版数を更新し、Astra の扱い（既定にしない。明示指定でのみ使う）を追記した。

このブランチは PR #96（Codex 委譲のモデルと effort の基準追加）の上に積んでいる。ベースは `feature/codex-model-effort-routing`。PR #96 を先にマージしてから、この PR のベースを `main` に付け替える。

## 影響調査で確認した事項

- `~/.codex/config.toml` の各キーは 0.153.4 のバイナリが全て認識する。廃止キーはない
- Claude Code の Codex プラグイン経由の 3 経路（task / `--write` / review）は 0.153.4 で実走して成功
- 0.150.0 から、`[projects]` で信頼していないディレクトリでは Codex がそのリポジトリの `AGENTS.md` を読まない
- プラグインは Claude Code セッションごとに `codex app-server` を常駐させる。CLI 更新前に起動したセッションは古いバイナリを使い続ける

## テスト計画

- [x] `bash -n` でスクリプト 3 本の構文を確認
- [x] `grep -rn "full-auto" private_dot_claude/` がフラグとしての使用 0 件（残る 1 件は `codex-config.md` の経緯説明）
- [x] `chezmoi apply` で実機の `~/.claude/skills` と `~/.claude/docs` へ反映し、`chezmoi verify` が通ることを確認
- [ ] review-doc / review-adr / peer-review を実際に 1 回ずつ走らせ、Codex CLI 0.153.4 で完走することを確認（レビュー対象が出たときに実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FKE5VzxAKe77faGD9X9fr
