### PR TITLE
feat(codex): Codex 向けスキル 3 本を dot_agents で管理し .codex/skills を対象外にする

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -6,3 +6,6 @@ Brewfile.lock.json
 docs/
 dot_ssh/
 private_dot_claude/skills/self-review/.gemini-cooldown
+
+# Codex 用のアカウント運用スキル（正本は ~/work/claude-code-account-manager）。組織固有の情報を含むため公開リポジトリの dotfiles では管理しない（2026-09-10 決定）
+.codex/skills

--- a/dot_agents/skills/codex-account/SKILL.md
+++ b/dot_agents/skills/codex-account/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: codex-account
+description: Codex CLI のアカウント切替・レート制限時の手動退避に使い、CODEX_HOME で設定と認証を分離する。既定アカウントだけで完結する通常のコーディング作業には使わない。
+---
+
+# Codex Account Switch Skill
+
+Codex CLI の設定ホームを `CODEX_HOME` で分離します。主アカウントは `~/.codex`、もう一方は `~/.codex-work` を使います。
+Claude Code から起動する場合も、委譲先 Codex は親プロセスの `CODEX_HOME` を引き継ぎます。**claude を起動したシェルの `CODEX_HOME` が委譲先 Codex のアカウントを決めます**。
+
+正本ドキュメント（再現手順の詳細）: dotfiles の `docs/account-switching.md`
+
+`~/.codex/config.toml` は chezmoi 管理外です。直接編集した内容は永続し、dotfiles リポジトリには含まれません。
+
+## 確定運用（この構成で管理する）
+
+| 項目 | 方針 |
+|---|---|
+| 既定アカウント | `~/.codex`（主）。全リポでこれ。env 不要 |
+| もう一方 | `~/.codex-work` |
+| 別アカウントが要るリポ | そのリポで `.envrc` に `CODEX_HOME` を pin（git-exclude する） |
+| 起動の習慣 | Claude Code 経由では、pin したリポは `cd <repo> && claude` で**中から起動**（委譲先 Codex が自動でそのアカウントになる） |
+| レートリミット退避 | **手動**。`codex-work` で起動し直す。自動 failover ラッパーは作らない |
+| 切替の粒度 | プロセスの起動単位。Claude Code 経由では claude を起動し直す。セッション中の `cd` では切替わらない（別アカウントなら起動し直す） |
+
+## 手順
+
+ユーザーの意図に応じて、以下のいずれかを実施します。
+
+### 0. セットアップスクリプト（推奨。手順 A・B をまとめて実行する）
+
+このスクリプトは前提チェックと設定の共有を行います。ログインは代行せず、未ログインならログイン用の 1 行を表示して終了します。
+
+```bash
+bash ~/.agents/skills/codex-account/scripts/setup-work-account.sh --check   # 状態を見るだけ
+bash ~/.agents/skills/codex-account/scripts/setup-work-account.sh           # セットアップを実行
+bash ~/.agents/skills/codex-account/scripts/setup-work-account.sh --pin     # カレントリポを固定
+```
+
+スクリプトには Claude Code 向けの案内が残っています。Codex では、ログイン用コマンドの先頭の `!` を外し、ユーザーのターミナルで実行してもらいます。
+その後スクリプトを再実行すると、`config.toml` のコピーと `AGENTS.md` のシンボリックリンクまで済みます。
+
+以下の A・B は、スクリプト内部の処理です。手作業で追う場合に参照します。
+
+### A. 初回セットアップ（もう一方のアカウントを追加する）
+
+1. **前提チェック**:
+   ```bash
+   command -v direnv >/dev/null && echo "direnv: OK" || echo "direnv: 未導入（brew install direnv が必要）"
+   [[ -d ~/.codex ]] && echo "主アカウント: OK" || echo "主アカウント: 未ログイン"
+   [[ -f ~/.codex-work/auth.json ]] && echo "work: ログイン済" || echo "work: 未ログイン"
+   ```
+
+2. **work が未ログインなら、ユーザーにログインを依頼**（対話ログインは代行しない）。
+   次の一行をユーザーのターミナルで実行してもらう:
+   ```
+   CODEX_HOME=~/.codex-work codex login
+   ```
+
+3. **ログイン確認後、設定を共有**:
+   ```bash
+   cp ~/.codex/config.toml ~/.codex-work/config.toml
+   ln -sf ~/.codex/AGENTS.md ~/.codex-work/AGENTS.md
+   ```
+   > config.toml はコピー（codex の atomic write で symlink が壊れるため）。AGENTS.md は codex が書き換えないので symlink で共有。
+
+### B. リポジトリを work アカウントに pin する
+
+カレント git リポを `~/.codex-work` に固定します。以下は zsh 関数 `codex-use-work` と同等の処理です。
+
+```bash
+root=$(git rev-parse --show-toplevel) || { echo "git リポ外"; exit 1; }
+echo 'export CODEX_HOME=$HOME/.codex-work' > "$root/.envrc"
+grep -qxF '.envrc' "$root/.git/info/exclude" 2>/dev/null || echo '.envrc' >> "$root/.git/info/exclude"
+command -v direnv >/dev/null && direnv allow "$root"
+echo "pinned $(basename "$root") -> ~/.codex-work (.envrc は git-excluded)"
+```
+
+Claude Code 経由で使う場合は、pin 後にそのリポで **`cd <repo> && claude`** と起動するよう案内します。claude 起動時に `CODEX_HOME` が確定します。
+
+### C. 状態確認 / ヘルスチェック
+
+```bash
+echo "主 (~/.codex):       $([[ -f ~/.codex/auth.json ]] && echo logged-in || echo none)"
+echo "work (~/.codex-work): $([[ -f ~/.codex-work/auth.json ]] && echo logged-in || echo none)"
+echo "現在の CODEX_HOME: ${CODEX_HOME:-(未設定 = 主アカウント)}"
+```
+
+pin 済みリポの検索は `~/work` の深さ 3 までとします。
+```bash
+find ~/work -maxdepth 3 -name .envrc -exec grep -l 'CODEX_HOME' {} + 2>/dev/null
+```
+
+## レートリミット退避（手動）
+
+主アカウントが上限に達したら、ユーザーが別アカウントで起動し直します。
+```bash
+# シェルで（エイリアスは zshrc 定義済み）
+codex-work
+```
+自動 failover（429 検知で別アカウント再試行するラッパー）は作りません。委譲先 Codex の常駐プロセスへの割り込みが壊れやすいためです。
+
+## アンチパターン
+
+| ❌ NG | ✅ OK |
+|---|---|
+| config.toml を symlink 共有 | config.toml はコピー、AGENTS.md のみ symlink |
+| 自動レートリミット failover ラッパーを作る | 手動で `codex-work` 起動し直す |
+| セッション中に cd で切替わると期待 | 別アカウントなら起動し直す。Claude Code 経由では claude を再起動 |
+
+## 認証が切れているときの見分け方
+
+この構成では Codex CLI の認証を `~/.codex/auth.json`（または `$CODEX_HOME/auth.json`）に保存します。
+このファイルが無ければ CLI は未認証です。委譲もレビュー系スクリプトも `401 Unauthorized: Missing bearer or basic authentication in header` で失敗します。
+
+確認時の注意点は次のとおりです。
+
+- **Codex デスクトップアプリや Web の ChatGPT にログインしていても、CLI の認証とは別物**である。
+  アプリ側でアカウントを切り替えても `auth.json` は作られない
+- 週間上限に達したときのエラーは 401 ではなく利用制限のメッセージになる。
+  401 が出たら上限ではなく**ログイン切れ**を疑う
+
+復旧時はログインし直します。ユーザーにターミナルで `codex login`（2 つ目なら `CODEX_HOME=$HOME/.codex-work codex login`）の実行を依頼します。
+
+## 関連
+
+- `~/.agents/skills/codex-account/scripts/setup-work-account.sh` — セットアップ・状態確認・リポジトリ固定を行うスクリプト
+- `~/.config`（dotfiles）の `docs/account-switching.md` — 再現手順の正本
+- `~/.zshrc` の `codex-work` エイリアス / `codex-use-work` 関数 / direnv hook

--- a/dot_agents/skills/codex-account/scripts/executable_setup-work-account.sh
+++ b/dot_agents/skills/codex-account/scripts/executable_setup-work-account.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Codex の 2 つ目のアカウント（~/.codex-work）を使える状態にするセットアップスクリプト。
+#
+# 何をするか:
+#   1. 前提（direnv / 主アカウントのログイン / 2 つ目のログイン）を確認する
+#   2. 主アカウントの config.toml を初回だけコピーし、AGENTS.md をシンボリックリンクで共有する
+#   3. 使い方を表示する
+#
+# 何をしないか:
+#   - ログインは代行しない。対話操作であり、このマシンの PreToolUse フック
+#     block-codex-direct.py が Bash ツール経由の codex 実行をブロックするため。
+#     未ログインならログイン用の 1 行を案内して終了する。
+#   - 自動フェイルオーバー（上限検知で自動的にアカウントを切り替える仕組み）は作らない。
+#     委譲先 Codex の常駐プロセスへの割り込みが壊れやすいため、切替は手動に留める。
+#
+# Usage:
+#   bash setup-work-account.sh              # セットアップを実行する
+#   bash setup-work-account.sh --check      # 状態を確認するだけ（変更しない）
+#   bash setup-work-account.sh --pin        # カレント git リポを 2 つ目のアカウントに固定する（direnv が必要）
+#
+# Exit codes:
+#   0 - 完了（--check は状態表示のみで 0）
+#   1 - 前提を満たしていない（主アカウント未ログイン等）
+#   2 - 2 つ目のアカウントが未ログイン。案内を表示済み
+
+set -uo pipefail
+
+MAIN_HOME="$HOME/.codex"
+WORK_HOME="$HOME/.codex-work"
+MODE="${1:-setup}"
+
+# 知らない引数をセットアップとして扱わない。--help や打ち間違いで config.toml の
+# コピーと AGENTS.md のリンク作成が走ると、意図しない変更に気づきにくい。
+case "$MODE" in
+  setup|--check|--pin) ;;
+  *)
+    echo "エラー: 知らない引数です: $MODE" >&2
+    echo "Usage: bash setup-work-account.sh [--check|--pin]" >&2
+    exit 1
+    ;;
+esac
+
+# 認証済みかどうかを判定する。codex は auth.json に認証情報を書く。
+is_logged_in() {
+  [[ -f "$1/auth.json" ]]
+}
+
+print_status() {
+  echo "現在の状態:"
+  echo "  主アカウント   ($MAIN_HOME):      $(is_logged_in "$MAIN_HOME" && echo 'ログイン済' || echo '未ログイン')"
+  echo "  2 つ目         ($WORK_HOME): $(is_logged_in "$WORK_HOME" && echo 'ログイン済' || echo '未ログイン')"
+  echo "  CODEX_HOME:                       ${CODEX_HOME:-（未設定 = 主アカウント）}"
+  if command -v direnv >/dev/null 2>&1; then
+    echo "  direnv:                           導入済（リポジトリ単位の固定が使える）"
+  else
+    echo "  direnv:                           未導入（brew install direnv でリポジトリ単位の固定が使える）"
+  fi
+}
+
+print_login_hint() {
+  echo ""
+  echo "2 つ目のアカウントにログインしてください。Claude Code からは代行できません。"
+  echo "Claude Code のプロンプトに次の 1 行を貼るか、ターミナルで直接実行します。"
+  echo ""
+  echo "  ! CODEX_HOME=$WORK_HOME codex login"
+  echo ""
+  echo "ログイン後にこのスクリプトを再実行すると、設定の共有まで済みます。"
+}
+
+# --- リポジトリ固定モード -----------------------------------------------------
+if [[ "$MODE" == "--pin" ]]; then
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "エラー: git リポジトリの中で実行してください" >&2
+    exit 1
+  }
+  # .envrc は direnv 専用のファイルで、direnv が無いと読まれない。未導入のまま書いても
+  # 固定は効かないので、先に失敗させる。
+  if ! command -v direnv >/dev/null 2>&1; then
+    echo "エラー: --pin には direnv が必要です。brew install direnv で導入してください" >&2
+    exit 1
+  fi
+  # $HOME はここでは展開しない。.envrc の中に文字列のまま置き、direnv の読み込み時に展開させる。
+  # shellcheck disable=SC2016
+  pin_line='export CODEX_HOME=$HOME/.codex-work'
+  if [[ ! -e "$root/.envrc" ]]; then
+    printf '%s\n' "$pin_line" > "$root/.envrc"
+  elif ! grep -qxF "$pin_line" "$root/.envrc"; then
+    # 既存の .envrc には他の設定が入っている可能性がある。上書きせず手動追記に委ねる。
+    echo "エラー: 既存の $root/.envrc を上書きしません。次の 1 行を手動で追記してください" >&2
+    echo "" >&2
+    echo "  $pin_line" >&2
+    exit 1
+  fi
+  # 除外ファイルの場所は git に解決させる。worktree では $root/.git がディレクトリ
+  # ではなくファイルなので、$root/.git/info/exclude は「Not a directory」で失敗する。
+  exclude_file=$(git rev-parse --git-path info/exclude 2>/dev/null) || {
+    echo "エラー: 除外ファイルの場所を解決できませんでした" >&2
+    exit 1
+  }
+  if ! grep -qxF '.envrc' "$exclude_file" 2>/dev/null; then
+    mkdir -p "$(dirname "$exclude_file")" || exit 1
+    if ! echo '.envrc' >> "$exclude_file"; then
+      echo "エラー: $exclude_file に .envrc を追記できませんでした" >&2
+      exit 1
+    fi
+  fi
+  # direnv allow が失敗すると .envrc は読み込まれない。成功として案内しない。
+  if ! direnv allow "$root"; then
+    echo "エラー: direnv allow に失敗しました。固定は有効になっていません" >&2
+    exit 1
+  fi
+  echo "固定しました: $(basename "$root") → $WORK_HOME"
+  echo ""
+  echo "このリポジトリでは 'cd $root && claude' と中から起動してください。"
+  echo "claude の起動時に CODEX_HOME が決まるため、起動後の cd では切り替わりません。"
+  exit 0
+fi
+
+# --- 状態確認モード -----------------------------------------------------------
+if [[ "$MODE" == "--check" ]]; then
+  print_status
+  if ! is_logged_in "$WORK_HOME"; then
+    print_login_hint
+  fi
+  exit 0
+fi
+
+# --- セットアップ本体 ---------------------------------------------------------
+print_status
+echo ""
+
+if ! is_logged_in "$MAIN_HOME"; then
+  echo "エラー: 主アカウントが未ログインです。先に次を実行してください。" >&2
+  echo "" >&2
+  echo "  ! codex login" >&2
+  exit 1
+fi
+
+if ! is_logged_in "$WORK_HOME"; then
+  print_login_hint
+  exit 2
+fi
+
+# config.toml はコピーする。codex が書き込むとき atomic write でシンボリックリンクを
+# 置き換えてしまうため、リンクでは共有できない。
+# コピーは初回だけにする。再実行で上書きすると、work 側で codex が書いた設定
+# （config.toml は chezmoi 管理外なので直接編集が正）が確認なしに消えるため。
+if [[ -e "$WORK_HOME/config.toml" ]]; then
+  echo "保持しました: 既存の work 側 config.toml（主アカウントの内容で上書きしません）"
+  echo "  主アカウントの設定へ揃え直すなら、次を手動で実行します。" >&2
+  echo "    cp $MAIN_HOME/config.toml $WORK_HOME/config.toml" >&2
+elif [[ -f "$MAIN_HOME/config.toml" ]]; then
+  cp "$MAIN_HOME/config.toml" "$WORK_HOME/config.toml"
+  echo "コピーしました: config.toml"
+else
+  echo "警告: $MAIN_HOME/config.toml が見つかりません。コピーを飛ばします" >&2
+fi
+
+# AGENTS.md は codex が書き換えないのでシンボリックリンクで共有できる。
+if [[ -f "$MAIN_HOME/AGENTS.md" ]]; then
+  ln -sf "$MAIN_HOME/AGENTS.md" "$WORK_HOME/AGENTS.md"
+  echo "リンクしました: AGENTS.md → $MAIN_HOME/AGENTS.md"
+else
+  echo "警告: $MAIN_HOME/AGENTS.md が見つかりません。リンクを飛ばします" >&2
+fi
+
+echo ""
+echo "セットアップが完了しました。使い方は次のとおりです。"
+echo ""
+echo "  1. 2 つ目のアカウントで Codex を使う:"
+echo "       codex-work                      # zshrc のエイリアス"
+echo ""
+echo "  2. 2 つ目のアカウントで Claude Code を起動する（委譲先 Codex も切り替わる）:"
+echo "       CODEX_HOME=$WORK_HOME claude"
+echo ""
+echo "  3. 特定のリポジトリを 2 つ目のアカウントに固定する:"
+echo "       bash $0 --pin                   # そのリポジトリの中で実行する"
+echo ""
+echo "主アカウントが週間上限に達したら、2 で起動し直して退避します。"
+exit 0

--- a/dot_agents/skills/db/SKILL.md
+++ b/dot_agents/skills/db/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: db
+description: MySQL の接続・クエリ実行・テーブル確認に使い、プロジェクトの接続プロファイルで実行して結果を表にまとめる。プロファイル設定（`.claude/db-profiles.json`）が無いプロジェクトや、MySQL 以外の DB には使わない。
+---
+
+# DB Query Skill
+
+Execute MySQL queries interactively with structured markdown output.
+
+## Input
+
+ユーザーの依頼からプロファイル名と SQL を読み取ります。プロファイル名の省略時は `"default": true` を使い、SQL の省略時は対話モードに入ります。
+
+## Procedure
+
+### 1. Load connection profile
+
+接続情報はプロジェクトの `.claude/db-profiles.json` をプロセス内で解析して取得します。このパスは既存の共有プロファイルの保存先です。ファイル全体や機密値をツール出力・ログに表示しません。
+
+- ファイルがない場合は処理を止め、下記の Profile format を案内
+- 指定プロファイルがない場合、または省略時に既定プロファイルがない場合はユーザーに選択を依頼
+
+### 2. Resolve password
+
+- `password` が `"FROM_SECRETS_MANAGER"` の場合、依頼や設定から secret name/ARN を特定。不明ならユーザーに確認
+- `aws secretsmanager get-secret-value` の応答はプロセス内で受け取り、JSON の password を抽出。標準出力へ表示しない
+- それ以外はプロファイルの password を使用
+
+パスワードはプロセス内で `MYSQL_PWD` 環境変数に設定して mysql 子プロセスへ渡します。`-p`、コマンド文字列、出力、ログには値を含めません。以下のコマンド例は、その環境変数を設定済みの子プロセスで実行します。
+
+### 3. Test connection
+
+日本語を扱うため、mysql には常に `--default-character-set=utf8mb4` を指定します。
+
+```bash
+mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> -e "SELECT 1" 2>&1
+```
+
+- If connection fails, show the error and suggest troubleshooting:
+  - Local: Is Docker running? `docker ps | grep mysql`
+  - Remote: Is SSM tunnel active? Check the port with `lsof -i :<port>`
+
+### 4. Execute query
+
+#### Safety checks BEFORE execution
+
+1. **Write operation detection** — Check if the query matches any write pattern (case-insensitive):
+   `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `CREATE`, `TRUNCATE`, `REPLACE`, `RENAME`, `GRANT`, `REVOKE`
+
+   - If `readonly: true` on the profile → **REFUSE execution**:
+     > This profile is read-only (`<profile_name>`, environment: `<env>`). Write operations are not allowed.
+   - If `readonly: false` → **WARN** and ask for explicit confirmation:
+     > ⚠️ This is a write operation on `<profile_name>` (`<env>`). Proceed? (yes/no)
+
+2. **LIMIT check** — For `SELECT` queries without `LIMIT` (and not subqueries):
+   - Automatically append `LIMIT 100`
+   - Inform the user: `Auto-applied LIMIT 100. Specify an explicit LIMIT to override.`
+
+#### Execute
+
+```bash
+mysql -h <host> -P <port> -u <user> --default-character-set=utf8mb4 <database> --column-names -B -e "<query>" 2>&1
+```
+
+- Use `--column-names -B` to obtain column names and tab-separated rows in one execution
+- Measure execution time
+
+### 5. Format output
+
+#### Query results (SELECT, SHOW, DESCRIBE, EXPLAIN)
+
+Use the column names and rows from step 4; do not rerun the query to format results.
+
+Format as markdown table:
+
+```markdown
+**Profile**: <name> | **Database**: <database> | **Rows**: <count>
+
+| col1 | col2 | col3 |
+|------|------|------|
+| val1 | val2 | val3 |
+
+_<execution_time>s_
+```
+
+- Truncate cell values longer than 60 characters with `...`
+- NULL values display as `NULL`
+
+#### SHOW TABLES — Enhanced output
+
+When the query is `SHOW TABLES` (or similar), also fetch row counts:
+
+```sql
+SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.TABLES WHERE TABLE_SCHEMA = '<database>' ORDER BY TABLE_NAME;
+```
+
+Format:
+
+```markdown
+**Database**: <database> | **Tables**: <count>
+
+| # | Table Name | Rows (approx) |
+|---|------------|---------------|
+| 1 | users      | ~150          |
+| 2 | orders     | ~1,200        |
+```
+
+#### Write operations (INSERT, UPDATE, DELETE)
+
+```markdown
+**Profile**: <name> | **Database**: <database>
+
+✅ Query executed successfully.
+Affected rows: <count>
+
+_<execution_time>s_
+```
+
+### 6. Interactive mode
+
+If the user did not provide a query:
+
+- After showing the result, ask the user for the next query
+- Continue until the user says "exit", "quit", or "done"
+- Each iteration: apply safety checks → execute → format output
+
+## Profile format
+
+`.claude/db-profiles.json` in the project root:
+
+```json
+{
+  "local": {
+    "host": "127.0.0.1",
+    "port": 3306,
+    "user": "root",
+    "password": "root",
+    "database": "myapp",
+    "description": "Local Docker MySQL",
+    "environment": "local",
+    "readonly": false,
+    "default": true
+  },
+  "staging": {
+    "host": "127.0.0.1",
+    "port": 13306,
+    "user": "admin",
+    "password": "FROM_SECRETS_MANAGER",
+    "database": "myapp",
+    "description": "Aurora MySQL staging (SSM tunnel on port 13306)",
+    "environment": "staging",
+    "readonly": true
+  }
+}
+```

--- a/dot_agents/skills/terraform-apply-recovery/SKILL.md
+++ b/dot_agents/skills/terraform-apply-recovery/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: terraform-apply-recovery
+description: Terraform / Terragrunt の apply 失敗・名前衝突・state のズレを復旧し、caller の凍結・再有効化や module の名前・内部構造の変更時にリソースと state の整合を保つために使う。これらに関係しない通常の plan / apply や新規モジュール作成には使わない。
+---
+
+# Terraform / Terragrunt Apply Recovery
+
+apply が失敗したとき、部分的にクラウド側に作られたリソースを放置しない。**「失敗 → 残骸放置 → 設計変更 → 再開時に衝突」** という事故が繰り返し起きる構造を断つためのプロセス。
+
+## 起動条件
+
+以下のいずれかに該当したら本スキルの判断ツリーに沿って進める:
+
+- terragrunt / terraform apply が exit 1 で停止した
+- `EntityAlreadyExists` / `AlreadyExists` / `409 Conflict` 等の名前衝突エラー
+- `Resource ... is not in the state` / `... already managed by Terraform` 等のドリフトエラー
+- caller の凍結フラグ（`enabled.<key> = false` / `exclude { if = ... }`）を `true` に戻して再有効化したい
+- module rename / 内部構造変更（リソース名変更、`count → for_each` 化、resource → module 化）を行いたい
+- AWS / GCP / Azure 側で「terraform 管理外のはずのリソース」を見つけた
+
+## 基本原則
+
+apply の途中失敗は AWS / GCP / Azure いずれの provider でも **ロールバックされない**。途中までに作成成功したリソースはそのまま残る。terraform 自身も rollback 機能を持たない。これを前提に動く。
+
+### 原則 1: apply 失敗は「タスク終了」ではなく「タスクの途中」
+
+失敗の瞬間からコード修正だけで再 apply するのは禁止。**残骸の所在を確認 → AWS 側 / state の整合を取り戻す → 0-diff 再 apply** までを 1 タスクで完結させる。
+
+### 原則 2: 凍結 ≠ destroy
+
+`enabled = false` や `exclude` で caller をスキップしても、**AWS 側の現物は削除されない**。state からの参照だけが切れる。「無いことにする」運用は孤児を生み続ける。
+
+### 原則 3: rename / 内部構造変更時は `moved` を書く
+
+`git mv` でファイルを動かしても terraform 視点ではリソースの logical address が切り替わるだけ。`moved {}` block / `terraform state mv` で **新旧の対応関係**を明示しないと、旧 state 行が宙に浮き、新 state は空のままで apply 時に重複 create を試行する。
+
+---
+
+## ステップ 1: failed apply 直後の first response
+
+apply が失敗したらすぐに以下の手順に入る。
+
+### 1-1. エラー分類
+
+apply ログから以下を判定する:
+
+| 兆候 | 分類 | 含意 |
+|---|---|---|
+| ログ冒頭から `Error: creating ...` | 1 件目から失敗 = 何も作られていない | state も AWS もクリーン。コード修正のみで再 apply 可 |
+| 一部リソースに `Creation complete after ...` が出た **後で**別リソースが Error | **部分成功 / 残骸あり** | 後始末必須（1-2 〜 1-4） |
+| `EntityAlreadyExists` / `AlreadyExists` / `409 Conflict` | 名前衝突 | 過去の残骸 or 別 stack 既存。1-2 〜 1-4 で整理 |
+| `Resource ... is not in the state` / refresh 時の不整合 | state ↔ AWS ドリフト | refresh / import で同期 |
+| `permission denied` / `AccessDenied` で 1 件目失敗 | 権限不足 | 残骸無し、IAM 修正のみで再 apply |
+| `permission denied` で **複数 step 後**失敗 | 部分成功 + 権限不足 | 残骸あり、後始末してから IAM 修正 |
+
+### 1-2. AWS 側の現物確認
+
+apply ログ上で `Creation complete` が出ているリソースを抽出 → AWS API / console で実在確認する。最低でも **失敗ステップ直前まで** の作成済みリソースを全て洗う。
+
+```bash
+# 例: IAM Policy の存在確認
+aws iam get-policy --policy-arn arn:aws:iam::<account>:policy/<name>
+
+# 例: Tag-based 横断検索（Project tag 等で絞る）
+aws resourcegroupstaggingapi get-resources \
+  --tag-filters Key=Project,Values=<project-name>
+
+# 例: terraform state vs AWS の差分検査
+terragrunt run -- state list   # state にあるリソース
+# → 各 resource を AWS API で実在確認
+```
+
+### 1-3. state との突き合わせ
+
+| state | AWS | 状態 | 対処 |
+|---|---|---|---|
+| ある | ある | 整合（problem-free） | コード修正で再 apply |
+| ある | 無い | state-only ghost | `terragrunt run -- state rm <addr>` |
+| 無い | ある | **孤児（orphan）** | 1-4 の 3 択 |
+| 無い | 無い | 何も無い | コード修正で再 apply |
+
+### 1-4. 残骸処理 3 択
+
+孤児（state 無し / AWS あり）を見つけたら以下から選ぶ。
+
+| 手段 | 用途 | 主要コマンド |
+|---|---|---|
+| **A. AWS 手動削除** | 残骸が孤立しており再作成が安全。最速 | console / `aws <service> delete-...` 系 |
+| **B. import block** | 残骸を保持して新 state に取り込みたい。ADR-008 等「全変更 CI/CD 経由」原則と整合 | `import { to = <addr>; id = "<aws-id>" }` を `.tf` に追記 → apply |
+| **C. destroy -target** | state にも AWS にも存在し、両方消したい | `terragrunt run -- destroy -target=<address>` |
+
+判断フロー:
+
+```
+孤児を発見
+  ├─ 残したい？
+  │    ├─ Yes → B（import block）
+  │    └─ No  → A（AWS 手動削除）
+  └─ state にもある？
+       └─ Yes → C（destroy -target で両方）
+```
+
+#### import block 例
+
+```hcl
+# 既存 IAM Policy を新 state に取り込む
+import {
+  to = aws_iam_policy.composer_env_access
+  id = "arn:aws:iam::448406925066:policy/wp-platform-dev-composer-env-access"
+}
+```
+
+apply 後に新 state に取り込まれる。drift があれば次の plan で update が走るので diff を必ず目視。取り込みが完了したら `import {}` block は削除する PR を別途出す（保持しても害は少ないが、責務が「初回取り込み」と明確なため）。
+
+### 1-5. 0-diff 再 apply
+
+整理が終わったら本来の作業に戻る前に必ず:
+
+```bash
+terragrunt run -- plan
+# → "No changes. Your infrastructure matches the configuration." を確認
+```
+
+これが出ない限り、まだ state と AWS が揃っていない。揃うまで 1-2 〜 1-4 を反復。
+
+---
+
+## ステップ 2: caller 凍結前のチェックリスト
+
+`enabled.<key> = false` や `exclude { if = ... }` で caller を凍結する前に必ず確認:
+
+- [ ] その caller を **過去に一度でも apply 試行したか**（git log で flag 履歴確認）
+- [ ] apply 試行があった場合、AWS 側にリソースが **残っていないか** 確認（1-2 と同手順）
+- [ ] 残っていれば **destroy** で空に揃える（**凍結は destroy ではない**）
+- [ ] 凍結理由 + 「AWS 側に残置リソース無しを確認した」記録を caller の terragrunt.hcl コメントに残す
+
+```bash
+# 凍結直前の最終確認
+terragrunt run -- plan       # 現在何があるか
+terragrunt run -- destroy    # 空にする（必要に応じて -target で個別）
+# その後 enabled = false を merge
+```
+
+凍結 = state からも参照しなくなる = **AWS の現物と state のズレを放置するスイッチ**。これを意識するだけで予防できる。
+
+---
+
+## ステップ 3: module rename / 内部構造変更
+
+ファイル名 / module 名 / リソース名 / 反復構造（count ↔ for_each）を変えるとき、terraform から見ると **logical address が変わる** ため state mv 操作が必須。
+
+### 使い分け表
+
+| 手段 | 用途 | 形式 |
+|---|---|---|
+| `moved {}` block | logical address が変わるだけで AWS 上のリソースは同じ。**最も推奨** | terraform 1.1+ |
+| `import {}` block | 既存 AWS リソースを新 state に取り込む（state に無いケース） | terraform 1.5+ |
+| `removed {}` block | 旧 state から外すが AWS では destroy しない | terraform 1.7+ |
+| `terraform state mv` | 命令的に state を移動 | CLI コマンド |
+
+`moved` / `import` / `removed` block は **コードに残せて CI/CD 経由で adopt できる** のが利点。`state mv` は CLI 経由なので「全変更 CI/CD 経由」原則のあるリポでは挟みづらい。新規実装は **block ベース推奨**。
+
+### moved block 例
+
+```hcl
+# module rename（旧 module path → 新 module path）
+moved {
+  from = module.composer_oidc_policy_attachment.aws_iam_policy.composer_env_access
+  to   = module.composer_execution_role.aws_iam_policy.composer_env_access
+}
+
+# count → for_each 化
+moved {
+  from = aws_instance.web[0]
+  to   = aws_instance.web["primary"]
+}
+```
+
+### removed block 例
+
+```hcl
+# 旧 module を消すが AWS のリソースは別管理に移したので残す
+removed {
+  from = module.legacy_logging
+  lifecycle {
+    destroy = false
+  }
+}
+```
+
+### 注意点
+
+- `moved` だけでは AWS 側の挙動は変わらない。**logical address のリラベル**だけ
+- 既存 state 行と新 module の resource 構成が **1:1 対応する** ことが前提。internal layout が変わる場合は moved を複数並べる
+- ファイル `git mv` だけだと state との接続が切れる。**moved block 必須**
+
+---
+
+## ステップ 4: 凍結フラグを true に戻すとき
+
+`enabled.<key> = false → true` に戻す PR は以下を必須にする:
+
+1. **plan を必ず目視**: `create` 行に既に AWS に存在するリソース名が出ていないか確認
+   - 出ていれば → ステップ 1（first response）の判断ツリーへ
+   - 出ていなければ → そのまま apply 可
+2. plan で問題があれば **import block** を同 PR に含める or 別 PR で先に整理
+3. apply 後 `plan` で **No changes** を再確認
+
+### 凍結期間が長い caller の典型事故
+
+```
+T+0    apply 試行 → 部分成功で fail
+T+0    flag = false で凍結（残骸放置）
+T+N日  module rename + 内部構造変更（moved 無し）
+T+M日  flag = true に戻す → apply で衝突 ← 今ここで気付く
+```
+
+このパターンを避けるには:
+- 凍結時点でステップ 2 のチェックリスト
+- rename 時にステップ 3 の moved block
+- 解凍時にステップ 4 の plan 目視
+
+---
+
+## CI / 運用ガード
+
+| 仕掛け | 目的 |
+|---|---|
+| 凍結 flag の ON↔OFF 切替 PR は plan 出力を PR description に貼る | レビュアーが create 行を目視できる |
+| drift detection の定期実行 | 月次等で `infra-initial-deploy.yml` の `action: plan` を回し diff を Issue 化 |
+| apply 失敗時の runbook 化 | failed apply に対する後処理（ステップ 1）を docs / Issue テンプレに固定 |
+| 命名規則に module 名を含める | 孤児が出ても由来が辿れる（例: `<project>-<env>-<module>-<purpose>`） |
+
+---
+
+## アンチパターン
+
+- ❌ apply 失敗をコード修正だけで再 apply → 半端な残骸が後で衝突
+- ❌ flag を false にして「とりあえず凍結」 → AWS 残置に気付かず後で爆発
+- ❌ module rename で `git mv` だけ、`moved` block 書かず → state 切断 → 再 apply で重複 create
+- ❌ destroy せず flag false で「無いことにする」 → 状態と現物の食い違いを放置
+- ❌ 部分成功時に `state rm` だけして AWS の現物を残す → 二重に孤児化
+- ❌ EntityAlreadyExists を見て「とりあえず import」と決め打ち → drift detection せず違う設定の現物を取り込む
+
+---
+
+## 参考
+
+- `~/.claude/rules/terraform-conventions.md`（規約・provider 等の不変ルール、本スキルの上位）
+- ADR-008（CI/CD 経由原則）— 「全変更 CI/CD 経由」原則のため、復旧手順も極力 CI/CD で回すこと
+- terraform 公式: [moved block](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring) / [import block](https://developer.hashicorp.com/terraform/language/import) / [removed block](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources)
+
+## 改訂ログ
+
+- v1（2026-05-09）: 初版。wp-platform Issue #461 / #461 関連 PR #573 のインシデント（composer-execution-role IAM Policy 衝突）を起点に整備。


### PR DESCRIPTION
## 概要

Codex が読むスキル置き場 `~/.agents/skills` の 3 スキル（codex-account / db / terraform-apply-recovery）を chezmoi のソース `dot_agents/skills/` で管理する。`dot_codex/config.seed.toml` の注記は「収録済み」と書いていたが、実際にはソースに未追跡のまま残っていたので、その食い違いを解消する。

- 3 スキルは Claude 側スキルの丸ごとコピーではなく、Codex 向けに description を短くし、引数の説明を書き直した版。実機の `~/.agents/skills` と同じ内容
- codex-account の setup スクリプトだけは、実機に残っていた古い版ではなく、[#92](https://github.com/phantom-suzuki/dotfiles/pull/92) で入った強化版（引数検証、worktree 対応、direnv 失敗検知、config.toml の上書き防止）と同じ内容にした。Claude 側と Codex 側で同じスクリプトを持つ
- `.chezmoiignore` に `.codex/skills` を追加。Codex 用のアカウント運用スキル `claude-account-rotation` は組織固有の情報を含み、正本が `~/work/claude-code-account-manager` にあるため、公開リポジトリの dotfiles では管理しない（2026-09-10 決定）

## 人手で行う工程

- 実機の `~/.agents/skills` は既に同じ内容のため、`chezmoi apply` で変わるのは setup スクリプトだけ
- 別マシンでは `chezmoi apply` 後に `~/.agents/skills` が生成される。`~/.codex/skills` は各マシンで手動管理

Closes [#115](https://github.com/phantom-suzuki/dotfiles/issues/115)

## テスト計画

- [x] `chezmoi --source <worktree> status ~/.agents ~/.codex` で、差分が setup スクリプトだけで `~/.codex/skills` が対象外になることを確認
- [x] 3 スキルの SKILL.md に社名・人名・URL・認証情報が無いことを grep で確認（残るのは HashiCorp 公式ドキュメントへのリンクと `FROM_SECRETS_MANAGER` のプレースホルダーだけ）
- [ ] マージ後に `chezmoi apply` を通常実行し、`chezmoi diff` が空になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Codex CLIの複数アカウント切り替え、状態確認、レート制限時の手動退避手順を追加。
  - 追加アカウントのセットアップ、リポジトリ固定、認証状態確認を行うスクリプトを追加。
  - MySQLの安全なクエリ実行、結果表示、対話モードに関するスキルを追加。
  - Terraform／Terragruntの適用失敗からの復旧手順を追加。
- **設定**
  - `.codex/skills`を公開対象外として設定し、管理方針をコメントで明記。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->