### PR TITLE
fix(chezmoi): リポジトリ直下の tests/ を実機に展開しないよう除外する

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -9,3 +9,6 @@ private_dot_claude/skills/self-review/.gemini-cooldown
 
 # Codex 用のアカウント運用スキル（正本は ~/work/claude-code-account-manager）。組織固有の情報を含むため公開リポジトリの dotfiles では管理しない（2026-09-10 決定）
 .codex/skills
+
+# リポジトリ直下の回帰テスト（PR #75）。実機には展開しない
+tests/


### PR DESCRIPTION
## 概要

[#75](https://github.com/phantom-suzuki/dotfiles/pull/75) で追加したリポジトリ直下の `tests/`（codex 直接実行ガードの回帰テスト）が、`.chezmoiignore` に無いため `chezmoi apply` で `~/tests/` に展開されてしまう状態だった。`docs/` と同じくリポジトリ専用のディレクトリなので、`.chezmoiignore` に `tests/` を追加する。

`chezmoi status` で `tests` が消えることを確認済み。実機への展開はまだ行っていない（apply 前に見つけた）。

Closes [#118](https://github.com/phantom-suzuki/dotfiles/issues/118)

## テスト計画

- [x] `chezmoi --source <worktree> status` に `tests` が出ない
- [ ] マージ後に `chezmoi apply` を実行し、`~/tests/` が作られないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
