### PR TITLE
feat(claude): モデルと effort を用途別に保存し claude-plan / claude-work で起動できるようにする

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -54,6 +54,12 @@ export VISUAL='nvim'
 # Worktree + Claude Code workflow
 [[ -f ~/.config/zsh/worktree.zsh ]] && source ~/.config/zsh/worktree.zsh
 
+# 用途別の Claude Code 起動。素の `claude` は司令塔用（settings.json の既定: Fable 5.1 1M / effort high）。
+# 以前撤去した全セッション共通の effort alias とは違い、素の `claude` の挙動は変えない。
+# 対応表は ~/.claude/docs/chezmoi-workflow.md の「用途別のモデルと effort」。
+claude-plan() { command claude --model 'opus[1m]' --effort high "$@"; }    # 段取りが決まっていて判断コストが多少ある作業
+claude-work() { command claude --model 'opus[1m]' --effort medium "$@"; }  # 司令塔の指示で動く作業者セッション
+
 # Starship prompt
 eval "$(starship init zsh)"
 

--- a/private_dot_claude/docs/chezmoi-workflow.md
+++ b/private_dot_claude/docs/chezmoi-workflow.md
@@ -44,9 +44,22 @@ chezmoi apply
 | コマンド | 更新する `chezmoi.toml` のキー |
 |---|---|
 | `/model` | `data.claude.model` |
+| `/effort` | `data.claude.modelSettings`（モデル ID ごとの `effortLevel`。テンプレート既定は Fable 5.1 = high、Opus 5 = medium） |
 | `/voice` | `data.claude.voice.mode` / `data.claude.voice.enabled` |
 | `/permissions`（既定モードの切り替え） | `data.claude.defaultMode` |
 | `/permissions`（auto mode のセットアップ。`soft_deny` / `environment`） | `data.claude.autoMode`（TOML の配列でそのまま持つ） |
+
+### 用途別のモデルと effort
+
+セッションの用途でモデルと effort を使い分ける。`settings.json` に持てる既定は 1 つなので、既定は司令塔用にし、他の用途は zsh の起動関数（`dot_zshrc.tmpl`）で `--model` と `--effort` を渡す。関数は素の `claude` の挙動を変えない。
+
+| 用途 | モデル / effort | 起動 |
+|---|---|---|
+| 司令塔・要件定義・判断が多い作業・基本設計 | Fable 5.1（1M）/ high | 素の `claude`（`settings.json` の既定） |
+| ロードマップや段取りが決まっていて判断コストが多少ある作業 | Opus 5（1M）/ high | `claude-plan` |
+| 司令塔の指示で動く作業者セッション | Opus 5（1M）/ medium | `claude-work` |
+
+セッション内で `/model` や `/effort` を使うと `settings.json` の `model` / `modelSettings` が書き換わる。恒久的に変えるなら上の表と `chezmoi.toml` の `[data.claude]` を更新し、一時的なら次の `chezmoi apply` で既定に戻ってよい。
 
 なお `settings.json` がコマンドで書き換わっていると `chezmoi apply` は「chezmoi が書いた後に変更されている」と検出して確認を求める。**確認を求められたら、まず `chezmoi diff` で意図しない巻き戻りが含まれていないかを見る**。`--force` で押し切る前に必ず差分を読むこと。
 

--- a/private_dot_claude/settings.json.tmpl
+++ b/private_dot_claude/settings.json.tmpl
@@ -10,6 +10,13 @@
   {{- if dig "claude" "effortLevel" "" . }}
   "effortLevel": {{ dig "claude" "effortLevel" "" . | toString | toJson }},
   {{- end }}
+  {{- /*
+    モデルごとの effort。用途別の使い分け（司令塔 = Fable 5.1 は high、作業者 = Opus 5 は medium）を
+    保存する。/effort は settings.json に直接書くため、マシン固有の値は data.claude.modelSettings で
+    丸ごと上書きする。キーはモデル ID（`[1m]` などのサフィックスを除いた形）。
+    用途別の起動コマンド（claude-plan / claude-work）は dot_zshrc.tmpl、説明は docs/chezmoi-workflow.md。
+  */}}
+  "modelSettings": {{ dig "claude" "modelSettings" (dict "claude-fable-5-1" (dict "effortLevel" "high") "claude-opus-5" (dict "effortLevel" "medium")) . | toJson }},
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",


### PR DESCRIPTION
## 概要

Claude Code のモデルと effort を用途別に 3 通り使い分けているが、`settings.json` に持てる既定は 1 つで、`/model` や `/effort` で直接書いた値は `chezmoi apply` で巻き戻る。2026-09-11 の棚卸しで、実機の `model: opus[1m]` と `modelSettings.claude-opus-5.effortLevel: medium` が chezmoi 側の `claude-fable-5-1[1m]` と食い違っていた。用途ごとの組み合わせを設定として保存し、起動コマンドで選べるようにする。

| 用途 | モデル / effort | 起動 |
|---|---|---|
| 司令塔・要件定義・判断が多い作業・基本設計 | Fable 5.1（1M）/ high | 素の `claude`（既定） |
| ロードマップや段取りが決まっていて判断コストが多少ある作業 | Opus 5（1M）/ high | `claude-plan` |
| 司令塔の指示で動く作業者セッション | Opus 5（1M）/ medium | `claude-work` |

## 変更内容

- `private_dot_claude/settings.json.tmpl`: `modelSettings` を出力する。既定は `claude-fable-5-1: high`、`claude-opus-5: medium`。マシン固有の値は `data.claude.modelSettings` で丸ごと上書きできる。`model` の既定は `claude-fable-5-1[1m]` のまま
- `dot_zshrc.tmpl`: `claude-plan` と `claude-work` の関数を追加。`command claude --model 'opus[1m]' --effort ...` で起動し、素の `claude` の挙動は変えない（Phase 0 で撤去した全セッション共通の effort alias とは別物）
- `private_dot_claude/docs/chezmoi-workflow.md`: `/effort` の対応キーと、上の用途表を追記

## 人手で行う工程

- 新しい関数はシェルを開き直すか `source ~/.zshrc` で有効になる
- このマシンは apply 後に既定が Fable 5.1 / high に戻る。Opus で作業するときは `claude-plan` / `claude-work` を使う

Closes [#120](https://github.com/phantom-suzuki/dotfiles/issues/120)

## テスト計画

- [x] 生成した `settings.json` が JSON として正しく、`model` と `modelSettings` が期待どおり
- [x] 生成した `.zshrc` が `zsh -n` を通る
- [ ] マージ後に `chezmoi apply` を実行し、`claude-plan` / `claude-work` が起動時に `--model` と `--effort` を渡すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
